### PR TITLE
Step1 지하철 노선 관리

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,25 @@
 <br>
 
 # 지하철 노선도 미션
+
 [ATDD 강의](https://edu.nextstep.camp/c/R89PYi5H) 실습을 위한 지하철 노선도 애플리케이션
+
+## 요구사항
+
+### step1
+
+- [ ] 기능 목록: 생성 / 목록 조회 / 조회 / 수정 / 삭제
+- [ ] 기능 구현 전 인수 테스트 작성
+- [ ] 기능 구현 후 인수 테스트 리팩터링
 
 <br>
 
 ## 🚀 Getting Started
 
 ### Install
+
 #### npm 설치
+
 ```
 cd frontend
 npm install

--- a/src/main/java/nextstep/subway/common/error/ErrorAdvice.java
+++ b/src/main/java/nextstep/subway/common/error/ErrorAdvice.java
@@ -1,6 +1,7 @@
 package nextstep.subway.common.error;
 
 import nextstep.subway.line.application.LineDuplicatedException;
+import nextstep.subway.line.application.LineNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,12 +11,18 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 @ResponseBody
 public class ErrorAdvice {
-
-    public static final String LINE_ALREADY_EXISTED = "이미 존재하는 노선을 생성할 수 없습니다";
+    private static final String LINE_ALREADY_EXISTED = "이미 존재하는 노선을 생성할 수 없습니다";
+    private static final String LINE_NOT_FOUND = "존재하지 않은 노선입니다.";
 
     @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(LineDuplicatedException.class)
     public ErrorResponse handleLineDuplicated() {
         return new ErrorResponse(LINE_ALREADY_EXISTED);
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(LineNotFoundException.class)
+    public ErrorResponse handleLineNotFound() {
+        return new ErrorResponse(LINE_NOT_FOUND);
     }
 }

--- a/src/main/java/nextstep/subway/common/error/ErrorAdvice.java
+++ b/src/main/java/nextstep/subway/common/error/ErrorAdvice.java
@@ -1,0 +1,21 @@
+package nextstep.subway.common.error;
+
+import nextstep.subway.line.application.LineDuplicatedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+@ResponseBody
+public class ErrorAdvice {
+
+    public static final String LINE_ALREADY_EXISTED = "이미 존재하는 노선을 생성할 수 없습니다";
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(LineDuplicatedException.class)
+    public ErrorResponse handleLineDuplicated() {
+        return new ErrorResponse(LINE_ALREADY_EXISTED);
+    }
+}

--- a/src/main/java/nextstep/subway/common/error/ErrorResponse.java
+++ b/src/main/java/nextstep/subway/common/error/ErrorResponse.java
@@ -1,0 +1,13 @@
+package nextstep.subway.common.error;
+
+public class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/nextstep/subway/line/application/LineDuplicatedException.java
+++ b/src/main/java/nextstep/subway/line/application/LineDuplicatedException.java
@@ -1,0 +1,20 @@
+package nextstep.subway.line.application;
+
+public class LineDuplicatedException extends RuntimeException {
+
+    public LineDuplicatedException() {
+        super();
+    }
+
+    public LineDuplicatedException(String message) {
+        super(message);
+    }
+
+    public LineDuplicatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LineDuplicatedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/nextstep/subway/line/application/LineNotFoundException.java
+++ b/src/main/java/nextstep/subway/line/application/LineNotFoundException.java
@@ -1,0 +1,20 @@
+package nextstep.subway.line.application;
+
+public class LineNotFoundException extends RuntimeException {
+
+    public LineNotFoundException() {
+        super();
+    }
+
+    public LineNotFoundException(String message) {
+        super(message);
+    }
+
+    public LineNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LineNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -52,4 +52,11 @@ public class LineService {
                 .orElseThrow(() -> new LineNotFoundException(LINE_NOT_EXISTED + lineId));
         line.update(request.toLine());
     }
+
+    @Transactional
+    public void deleteLine(long lineId) {
+        final Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new LineNotFoundException(LINE_NOT_EXISTED + lineId));
+        lineRepository.delete(line);
+    }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -7,16 +7,24 @@ import nextstep.subway.line.dto.LineResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
+    private static final String EXIST_LINE = "이미 존재하는 노선입니다 :";
+    private final LineRepository lineRepository;
 
     public LineService(LineRepository lineRepository) {
         this.lineRepository = lineRepository;
     }
 
     public LineResponse saveLine(LineRequest request) {
+        Optional<Line> findLine = lineRepository.findByName(request.getName());
+
+        if (findLine.isPresent()) {
+            throw new LineDuplicatedException(EXIST_LINE + request.getName());
+        }
         Line persistLine = lineRepository.save(request.toLine());
         return LineResponse.of(persistLine);
     }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -45,4 +45,11 @@ public class LineService {
                 .orElseThrow(() -> new LineNotFoundException(LINE_NOT_EXISTED + lineId));
         return LineResponse.of(line);
     }
+
+    @Transactional
+    public void updateLine(Long lineId, LineRequest request) {
+        final Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new LineNotFoundException(LINE_NOT_EXISTED + lineId));
+        line.update(request.toLine());
+    }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.toList;
 @Transactional(readOnly = true)
 public class LineService {
     private static final String EXIST_LINE = "이미 존재하는 노선입니다 :";
+    private static final String LINE_NOT_EXISTED = "노선이 존재하지 않습니다 :";
     private final LineRepository lineRepository;
 
     public LineService(LineRepository lineRepository) {
@@ -37,5 +38,11 @@ public class LineService {
                 .stream()
                 .map(LineResponse::of)
                 .collect(toList());
+    }
+
+    public LineResponse getLine(Long lineId) {
+        final Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new LineNotFoundException(LINE_NOT_EXISTED + lineId));
+        return LineResponse.of(line);
     }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -7,10 +7,13 @@ import nextstep.subway.line.dto.LineResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
+import static java.util.stream.Collectors.toList;
+
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class LineService {
     private static final String EXIST_LINE = "이미 존재하는 노선입니다 :";
     private final LineRepository lineRepository;
@@ -19,13 +22,20 @@ public class LineService {
         this.lineRepository = lineRepository;
     }
 
+    @Transactional
     public LineResponse saveLine(LineRequest request) {
         Optional<Line> findLine = lineRepository.findByName(request.getName());
-
         if (findLine.isPresent()) {
             throw new LineDuplicatedException(EXIST_LINE + request.getName());
         }
         Line persistLine = lineRepository.save(request.toLine());
         return LineResponse.of(persistLine);
+    }
+
+    public List<LineResponse> getLines() {
+        return lineRepository.findAll()
+                .stream()
+                .map(LineResponse::of)
+                .collect(toList());
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -2,5 +2,8 @@ package nextstep.subway.line.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -3,6 +3,7 @@ package nextstep.subway.line.dto;
 import nextstep.subway.line.domain.Line;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class LineResponse {
     private Long id;
@@ -44,5 +45,18 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LineResponse)) return false;
+        LineResponse that = (LineResponse) o;
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -3,13 +3,16 @@ package nextstep.subway.line.ui;
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/lines")
@@ -24,5 +27,10 @@ public class LineController {
     public ResponseEntity createLine(@RequestBody LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<LineResponse>> getLines() {
+        return ResponseEntity.ok().body(lineService.getLines());
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -6,6 +6,7 @@ import nextstep.subway.line.dto.LineResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +33,10 @@ public class LineController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<LineResponse>> getLines() {
         return ResponseEntity.ok().body(lineService.getLines());
+    }
+
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<LineResponse> getLine(@PathVariable Long id) {
+        return ResponseEntity.ok().body(lineService.getLine(id));
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -5,6 +5,7 @@ import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,5 +46,11 @@ public class LineController {
     public ResponseEntity updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
         lineService.updateLine(id, lineRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id:\\d+}")
+    public ResponseEntity deleteLine(@PathVariable Long id) {
+        lineService.deleteLine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,8 +36,14 @@ public class LineController {
         return ResponseEntity.ok().body(lineService.getLines());
     }
 
-    @GetMapping(value = "/{id}")
+    @GetMapping("/{id:\\d+}")
     public ResponseEntity<LineResponse> getLine(@PathVariable Long id) {
         return ResponseEntity.ok().body(lineService.getLine(id));
+    }
+
+    @PutMapping("/{id:\\d+}")
+    public ResponseEntity updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-handlebars.suffix=.html
-handlebars.enabled=true
-
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+
+handlebars:
+  suffix: .html
+  enabled: true
+
+

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -1,18 +1,13 @@
 package nextstep.subway.line.accpetance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
 
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
@@ -20,26 +15,12 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // when
-        // 지하철_노선_생성_요청
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "신분당선");
-        params.put("color", "red");
-
-        ExtractableResponse<Response> response = RestAssured.given().log().all().
-                body(params).
-                contentType(MediaType.APPLICATION_JSON_VALUE).
-                when().
-                post("/lines").
-                then().
-                log().all().
-                extract();
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청("신분당선", "red");
 
         // then
-        // 지하철_노선_생성됨
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        지하철_노선_생성됨(response);
     }
-
+    
     @DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")
     @Test
     void createLine2() {

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -1,8 +1,18 @@
-package nextstep.subway.line;
+package nextstep.subway.line.accpetance;
 
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
@@ -11,9 +21,23 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void createLine() {
         // when
         // 지하철_노선_생성_요청
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "red");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all().
+                body(params).
+                contentType(MediaType.APPLICATION_JSON_VALUE).
+                when().
+                post("/lines").
+                then().
+                log().all().
+                extract();
 
         // then
         // 지하철_노선_생성됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
     }
 
     @DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -13,6 +13,8 @@ import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_실패됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_응답됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_조회_요청;
 
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
@@ -53,20 +55,19 @@ public class LineAcceptanceTest extends AcceptanceTest {
         // then
         지하철_노선_목록_응답됨(response);
         지하철_노선_목록_포함됨(createResponse1, createResponse2, response);
-
     }
 
     @DisplayName("지하철 노선을 조회한다.")
     @Test
     void getLine() {
         // given
-        // 지하철_노선_등록되어_있음
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음("2호선", "green");
 
         // when
-        // 지하철_노선_조회_요청
+        ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
 
         // then
-        // 지하철_노선_응답됨
+        지하철_노선_응답됨(response);
     }
 
     @DisplayName("지하철 노선을 수정한다.")

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_등록되어_있음;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_응답됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_조회_요청;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_포함됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_실패됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
@@ -41,15 +44,16 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        // 지하철_노선_등록되어_있음
-        // 지하철_노선_등록되어_있음
+        ExtractableResponse<Response> createResponse1 = 지하철_노선_등록되어_있음("2호선", "green");
+        ExtractableResponse<Response> createResponse2 = 지하철_노선_등록되어_있음("3호선", "orange");
 
         // when
-        // 지하철_노선_목록_조회_요청
+        ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
 
         // then
-        // 지하철_노선_목록_응답됨
-        // 지하철_노선_목록_포함됨
+        지하철_노선_목록_응답됨(response);
+        지하철_노선_목록_포함됨(createResponse1, createResponse2, response);
+
     }
 
     @DisplayName("지하철 노선을 조회한다.")

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -6,6 +6,8 @@ import nextstep.subway.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_등록되어_있음;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_실패됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
 
@@ -20,19 +22,20 @@ public class LineAcceptanceTest extends AcceptanceTest {
         // then
         지하철_노선_생성됨(response);
     }
-    
+
     @DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")
     @Test
     void createLine2() {
         // given
-        // 지하철_노선_등록되어_있음
+        지하철_노선_등록되어_있음("2호선", "green");
 
         // when
-        // 지하철_노선_생성_요청
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
 
         // then
-        // 지하철_노선_생성_실패됨
+        지하철_노선_생성_실패됨(response);
     }
+
 
     @DisplayName("지하철 노선 목록을 조회한다.")
     @Test

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -10,12 +10,14 @@ import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_응답됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_조회_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_목록_포함됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_삭제됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_실패됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_수정_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_수정됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_응답됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_제거_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_조회_요청;
 
 @DisplayName("지하철 노선 관련 기능")
@@ -90,12 +92,12 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        // 지하철_노선_등록되어_있음
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음("2호선", "green");
 
         // when
-        // 지하철_노선_제거_요청
+        ExtractableResponse<Response> response = 지하철_노선_제거_요청(createResponse);
 
         // then
-        // 지하철_노선_삭제됨
+        지하철_노선_삭제됨(response);
     }
 }

--- a/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/accpetance/LineAcceptanceTest.java
@@ -13,6 +13,8 @@ import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_실패됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성_요청;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_생성됨;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_수정_요청;
+import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_수정됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_응답됨;
 import static nextstep.subway.line.accpetance.step.LineAcceptanceStep.지하철_노선_조회_요청;
 
@@ -74,14 +76,15 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        // 지하철_노선_등록되어_있음
+        ExtractableResponse<Response> createResponse = 지하철_노선_등록되어_있음("2호선", "green");
 
         // when
-        // 지하철_노선_수정_요청
+        ExtractableResponse<Response> response = 지하철_노선_수정_요청(createResponse);
 
         // then
-        // 지하철_노선_수정됨
+        지하철_노선_수정됨(response);
     }
+
 
     @DisplayName("지하철 노선을 제거한다.")
     @Test

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -33,4 +33,12 @@ public class LineAcceptanceStep {
                 extract();
         return response;
     }
+
+    public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(String name, String color) {
+        return 지하철_노선_생성_요청(name, color);
+    }
+
+    public static void 지하철_노선_생성_실패됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
 }

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -101,4 +101,17 @@ public class LineAcceptanceStep {
     public static void 지하철_노선_수정됨(ExtractableResponse<Response> response) {
         Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
+
+    public static void 지하철_노선_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_제거_요청(ExtractableResponse<Response> createResponse) {
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .delete(createResponse.header(LOCATION))
+                .then().log().all()
+                .extract();
+        return response;
+    }
 }

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.line.dto.LineResponse;
+import org.assertj.core.api.Assertions;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -84,5 +85,20 @@ public class LineAcceptanceStep {
     public static void 지하철_노선_응답됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getObject("", LineResponse.class)).isNotNull();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(ExtractableResponse<Response> createResponse) {
+        Map<String, String> params = new HashMap<>();
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(createResponse.header(LOCATION))
+                .then().log().all().extract();
+        return response;
+    }
+
+    public static void 지하철_노선_수정됨(ExtractableResponse<Response> response) {
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -17,9 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineAcceptanceStep {
 
+    public static final String LOCATION = "Location";
+
     public static void 지하철_노선_생성됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        assertThat(response.header(LOCATION)).isNotBlank();
     }
 
     public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
@@ -69,5 +71,18 @@ public class LineAcceptanceStep {
                 .when().get("lines")
                 .then().log().all().extract();
         return response;
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(ExtractableResponse<Response> createResponse) {
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when().get(createResponse.header(LOCATION))
+                .then().log().all().extract();
+        return response;
+    }
+
+    public static void 지하철_노선_응답됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getObject("", LineResponse.class)).isNotNull();
     }
 }

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -1,0 +1,36 @@
+package nextstep.subway.line.accpetance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineAcceptanceStep {
+
+    public static void 지하철_노선_생성됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+        params.put("color", color);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all().
+                body(params).
+                contentType(MediaType.APPLICATION_JSON_VALUE).
+                when().
+                post("/lines").
+                then().
+                log().all().
+                extract();
+        return response;
+    }
+}

--- a/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/accpetance/step/LineAcceptanceStep.java
@@ -3,11 +3,15 @@ package nextstep.subway.line.accpetance.step;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,5 +44,30 @@ public class LineAcceptanceStep {
 
     public static void 지하철_노선_생성_실패됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    public static void 지하철_노선_목록_응답됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 지하철_노선_목록_포함됨(
+            ExtractableResponse<Response> createResponse1,
+            ExtractableResponse<Response> createResponse2,
+            ExtractableResponse<Response> response) {
+        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
+                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
+                .collect(Collectors.toList());
+        List<Long> resultLineIds = response.jsonPath().getList(".", LineResponse.class).stream()
+                .map(it -> it.getId())
+                .collect(Collectors.toList());
+        assertThat(resultLineIds).containsAll(expectedLineIds);
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when().get("lines")
+                .then().log().all().extract();
+        return response;
     }
 }

--- a/src/test/java/nextstep/subway/line/application/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/application/LineServiceTest.java
@@ -1,0 +1,47 @@
+package nextstep.subway.line.application;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LineServiceTest {
+
+    @Mock
+    private LineRepository lineRepository;
+
+    private LineService lineService;
+
+    @BeforeEach
+    void setUp() {
+        lineService = new LineService(lineRepository);
+    }
+
+    @DisplayName("라인을 생성요청하면, 생성된 라인을 리턴한다.")
+    @Test
+    void createLine() {
+        // given
+        final LineRequest lineRequest = new LineRequest("2호선", "green");
+        final Line line = new Line("2호선", "green");
+        when(lineRepository.save(any(Line.class)))
+                .thenReturn(line);
+
+        // when
+        LineResponse actual = lineService.saveLine(lineRequest);
+
+        // then
+        assertThat(actual).extracting("name").isEqualTo("2호선");
+        assertThat(actual).extracting("color").isEqualTo("green");
+    }
+}

--- a/src/test/java/nextstep/subway/line/application/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/application/LineServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -75,5 +76,27 @@ class LineServiceTest {
         List<LineResponse> lines = lineService.getLines();
 
         assertThat(lines).containsExactly(LineResponse.of(line));
+    }
+
+    @DisplayName("노선 식별자에 해당하는 노선을 리턴한다.")
+    @Test
+    void getLineWithValidId() {
+        when(lineRepository.findById(anyLong()))
+                .thenReturn(Optional.of(line));
+
+        LineResponse line = lineService.getLine(anyLong());
+
+        assertThat(line).extracting("name").isEqualTo("2호선");
+        assertThat(line).extracting("color").isEqualTo("green");
+    }
+
+    @DisplayName("존재하지않는 노선 식별자 요청시 예외를 던짐.")
+    @Test
+    void getLineWithNotExistedId() {
+        when(lineRepository.findById(anyLong()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> lineService.getLine(anyLong()))
+                .isInstanceOf(LineNotFoundException.class);
     }
 }

--- a/src/test/java/nextstep/subway/line/application/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/application/LineServiceTest.java
@@ -11,8 +11,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,25 +27,40 @@ class LineServiceTest {
 
     private LineService lineService;
 
+    private LineRequest lineRequest;
+    private Line line;
+
     @BeforeEach
     void setUp() {
         lineService = new LineService(lineRepository);
+        line = new Line("2호선", "green");
+        lineRequest = new LineRequest("2호선", "green");
     }
 
-    @DisplayName("라인을 생성요청하면, 생성된 라인을 리턴한다.")
+    @DisplayName("노선을 생성요청하면, 생성된 노선을 리턴한다.")
     @Test
-    void createLine() {
+    void createLineWithValidLine() {
         // given
-        final LineRequest lineRequest = new LineRequest("2호선", "green");
-        final Line line = new Line("2호선", "green");
         when(lineRepository.save(any(Line.class)))
                 .thenReturn(line);
 
         // when
-        LineResponse actual = lineService.saveLine(lineRequest);
+        final LineResponse actual = lineService.saveLine(lineRequest);
 
         // then
         assertThat(actual).extracting("name").isEqualTo("2호선");
         assertThat(actual).extracting("color").isEqualTo("green");
+    }
+
+    @DisplayName("이미 존재하는 노선에 동일 노선 생성시, 예외를 던진다.")
+    @Test
+    void createLineWithDuplicatedLine() {
+        // given
+        when(lineRepository.findByName(anyString()))
+                .thenReturn(Optional.of(line));
+
+        // then
+        assertThatThrownBy(() -> lineService.saveLine(lineRequest))
+                .isInstanceOf(LineDuplicatedException.class);
     }
 }

--- a/src/test/java/nextstep/subway/line/application/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/application/LineServiceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,5 +64,16 @@ class LineServiceTest {
         // then
         assertThatThrownBy(() -> lineService.saveLine(lineRequest))
                 .isInstanceOf(LineDuplicatedException.class);
+    }
+
+    @DisplayName("모든 노선을 리턴한다.")
+    @Test
+    void getLines() {
+        when(lineRepository.findAll())
+                .thenReturn(Collections.singletonList(line));
+
+        List<LineResponse> lines = lineService.getLines();
+
+        assertThat(lines).containsExactly(LineResponse.of(line));
     }
 }

--- a/src/test/java/nextstep/subway/line/application/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/application/LineServiceTest.java
@@ -130,4 +130,25 @@ class LineServiceTest {
         assertThatThrownBy(() -> lineService.updateLine(eq(NOT_EXIST_ID), lineRequest))
                 .isInstanceOf(LineNotFoundException.class);
     }
+
+    @DisplayName("유효한 노선 삭제시 노선이 삭제된다 .")
+    @Test
+    void deleteLineWithValidRequest() {
+        when(lineRepository.findById(EXIST_ID))
+                .thenReturn(Optional.of(line));
+
+        lineService.deleteLine(EXIST_ID);
+
+        verify(lineRepository).delete(any(Line.class));
+    }
+
+    @DisplayName("존재하지않는 노선 삭제시 예외를 던짐.")
+    @Test
+    void deleteLineWithNotExistedId() {
+        when(lineRepository.findById(eq(NOT_EXIST_ID)))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> lineService.deleteLine(anyLong()))
+                .isInstanceOf(LineNotFoundException.class);
+    }
 }

--- a/src/test/java/nextstep/subway/line/domain/LineTest.java
+++ b/src/test/java/nextstep/subway/line/domain/LineTest.java
@@ -1,0 +1,40 @@
+package nextstep.subway.line.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LineTest {
+
+    private Line line;
+
+    @BeforeEach
+    void setUp() {
+        line = new Line("2호선", "green");
+    }
+
+    @DisplayName("노선을 생성하여 생성된 값을 리턴할 수 있다.")
+    @Test
+    void create() {
+        Line line = new Line("2호선", "green");
+
+        assertThat(line.getName()).isEqualTo("2호선");
+        assertThat(line.getColor()).isEqualTo("green");
+    }
+
+    @DisplayName("주어진 노선을 새로운 노선으로 갱신한다.")
+    @Test
+    void update() {
+        // given
+        Line line = new Line("3호선", "orange");
+
+        // when
+        line.update(new Line("5호선", "purple"));
+
+        // then
+        assertThat(line.getName()).isEqualTo("5호선");
+        assertThat(line.getColor()).isEqualTo("purple");
+    }
+}

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -2,6 +2,7 @@ package nextstep.subway.line.ui;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nextstep.subway.line.application.LineService;
+import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,8 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -36,7 +35,7 @@ class LineControllerTest {
     protected ObjectMapper objectMapper;
 
     private LineRequest lineRequest = new LineRequest("2호선", "green");
-    private LineResponse lineResponse = new LineResponse(1L, "3호선", "orange", LocalDateTime.now(), LocalDateTime.now());
+    private LineResponse lineResponse = LineResponse.of(new Line("2호선", "green"));
 
     @Nested
     @DisplayName("POST /lines는")

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -57,7 +57,6 @@ class LineControllerTest {
             void It_responds_create() throws Exception {
                 mockMvc.perform(
                         post("/lines")
-                                .accept(MediaType.APPLICATION_JSON_UTF8)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(givenLineRequest))
                 )

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -1,6 +1,70 @@
 package nextstep.subway.line.ui;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.subway.line.application.LineService;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
 class LineControllerTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LineService lineService;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    private LineRequest lineRequest = new LineRequest("2호선", "green");
+    private LineResponse lineResponse = new LineResponse(1L, "3호선", "orange", LocalDateTime.now(), LocalDateTime.now());
+
+    @Nested
+    @DisplayName("POST /lines는")
+    class Describe_create_line {
+
+        @Nested
+        @DisplayName("노선이 주어지면")
+        class Context_with_line {
+            final LineRequest givenLineRequest = lineRequest;
+
+            @BeforeEach
+            void setUp() {
+                when(lineService.saveLine(any(LineRequest.class)))
+                        .thenReturn(lineResponse);
+            }
+
+            @DisplayName("201 create를 응답한다.")
+            @Test
+            void It_responds_create() throws Exception {
+                mockMvc.perform(
+                        post("/lines")
+                                .accept(MediaType.APPLICATION_JSON_UTF8)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(givenLineRequest))
+                )
+                        .andExpect(status().isCreated());
+            }
+        }
+    }
 
 }

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -1,0 +1,6 @@
+package nextstep.subway.line.ui;
+
+class LineControllerTest {
+
+
+}

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -17,9 +17,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -85,6 +91,47 @@ class LineControllerTest {
                                 .content(objectMapper.writeValueAsString(givenLineRequest))
                 )
                         .andExpect(status().isConflict());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /lines는")
+    class Describe_getLines {
+        @Nested
+        @DisplayName("등록된 노선이 있으면")
+        class Context_with_lines {
+            List<LineResponse> lines;
+
+            @BeforeEach
+            void setUp() {
+                lines = Collections.singletonList(lineResponse);
+                when(lineService.getLines())
+                        .thenReturn(lines);
+            }
+
+            @DisplayName("200 OK 상태와 노선 목록을 응답한다.")
+            @Test
+            void It_responds_ok_with_lines() throws Exception {
+                mockMvc.perform(
+                        get("/lines")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(objectMapper.writeValueAsString(lines)));
+            }
+        }
+
+        @Nested
+        @DisplayName("등록된 노선이 없으면")
+        class Context_without_lines {
+
+            @DisplayName("200 OK 상태와 비어있는 노선 목록을 응답한다.")
+            @Test
+            void It_responds_ok_with_empty_lines() throws Exception {
+                mockMvc.perform(get("/lines"))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string(containsString("[]")));
             }
         }
     }

--- a/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
+++ b/src/test/java/nextstep/subway/line/ui/LineControllerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -229,6 +230,42 @@ class LineControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(givenRequest)))
                         .andExpect(status().isOk());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /lines/{id} 는")
+    class Describe_deleteLine {
+
+        @Nested
+        @DisplayName("삭제 대상인 노선이 없으면")
+        class Context_without_line {
+            @BeforeEach
+            void setUp() {
+                doThrow(new LineNotFoundException())
+                        .when(lineService)
+                        .deleteLine(eq(NOT_EXIST_ID));
+            }
+
+            @DisplayName("404 Not Found 상태를 응답한다.")
+            @Test
+            void It_responds_not_found() throws Exception {
+                mockMvc.perform(delete("/lines/{id}", NOT_EXIST_ID))
+                        .andExpect(status().isNotFound());
+            }
+        }
+
+        @Nested
+        @DisplayName("삭제 대상인 노선이 존재하면")
+        class Context_with_line {
+
+            @DisplayName("204 NO CONTENT 상태를 응답한다.")
+            @Test
+            void It_responds_no_content() throws Exception {
+                mockMvc.perform(delete("/lines/{id}", anyLong())
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                        .andExpect(status().isNoContent());
             }
         }
     }


### PR DESCRIPTION
안녕하세요, ATDD 사이클에 따라 재미있게 구현하였습니다. 
TDD 사이클과 인수테스트가 같이 통과하니 기분이 좋네요.

프런트에서 테스트해보려고 했는데, 미션 이미지랑 저희 프로젝트랑 화면이 조금 다른 것같아
화면 테스트는 해보지 못했어요.
![스크린샷 2021-05-31 오후 2 53 36](https://user-images.githubusercontent.com/8775409/120146549-3b9fc300-c220-11eb-83db-eed10a3a75d8.png)

### 궁금한점 🤔
1. application yml 설정 파일에서 profile을 설정안했는데 ```@ActiveProfiles("test")``` 이 있는 부분을 발견했어요. 테스트 내 profile은 자동으로 test으로 설정해주는지 따로 만들어야하는지 궁금하네요. 
2. test내 database cleanup 유틸은 혹시 공식 사이트에서 제공해주는 소스인가요? 
3. rest assured가 BDD 스타일의 테스트 라이브러리라고 알고있는데, mockito랑 같이 써도될지. 기능이 비슷하면 라이브러리 통합을 해야할까요?
4. 개발하면서 ```GET /lines``` URL이 겹쳐서 좀 헤맸습니다. ```produces = MediaType.APPLICATION_JSON_VALUE```외에 ```consume```도 써야할까요?
5. controller단의 메서드명을 잘 짓는 방법이 있는지 궁금하네요. 그냥 ```create, update, delete, put```으로 두시는 편인가요?
6. NEXTSTEP JPA 미션 피드백 내용중에 JPA와 equals&hash 사용시 식별자만으로도 충분하다는 것을 봤는데요. 그 엔티티를 감싸는 dto도 비교가 필요하면 이것도 식별자만으로 비교해도될지 궁금하네요