### PR TITLE
step4) 구간 제거 기능 리뷰 요청드립니다!

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -6,7 +6,6 @@ import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.section.application.SectionService;
 import nextstep.subway.section.domain.Section;
-import nextstep.subway.section.domain.Sections;
 import nextstep.subway.section.dto.SectionRequest;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
@@ -77,9 +76,8 @@ public class LineService {
     @Transactional
     public void removeSectionByStationId(Long lineId, Long stationId) {
         Line line = findById(lineId);
-        Sections sections = line.getSections();
         Station station = stationService.findById(stationId);
-        Section removeTarget = sections.remove(station);
+        Section removeTarget = line.remove(station);
         sectionService.deleteSection(removeTarget);
     }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -5,6 +5,8 @@ import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.section.application.SectionService;
+import nextstep.subway.section.domain.Section;
+import nextstep.subway.section.domain.Sections;
 import nextstep.subway.section.dto.SectionRequest;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
@@ -70,5 +72,14 @@ public class LineService {
         Station upStation = stationService.findById(sectionRequest.getUpStationId());
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         sectionService.saveSection(persistLine, upStation, downStation, sectionRequest.getDistance());
+    }
+
+    @Transactional
+    public void removeSectionByStationId(Long lineId, Long stationId) {
+        Line line = findById(lineId);
+        Sections sections = line.getSections();
+        Station station = stationService.findById(stationId);
+        Section removeTarget = sections.remove(station);
+        sectionService.deleteSection(removeTarget);
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -49,6 +49,10 @@ public class Line extends BaseEntity {
         section.toLine(this);
     }
 
+    public Section remove(Station station) {
+        return sections.remove(station);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -56,4 +56,10 @@ public class LineController {
         LineResponse line = lineService.findLine(lineId);
         return ResponseEntity.ok().body(line);
     }
+
+    @DeleteMapping("/lines/{lineId}/sections")
+    public ResponseEntity removeLineStation(@PathVariable Long lineId, @RequestParam Long stationId) {
+        lineService.removeSectionByStationId(lineId, stationId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/nextstep/subway/section/application/SectionService.java
+++ b/src/main/java/nextstep/subway/section/application/SectionService.java
@@ -27,4 +27,9 @@ public class SectionService {
     public void deleteSections(Sections sections) {
         sectionRepository.deleteAll(sections);
     }
+
+    @Transactional
+    public void deleteSection(Section section) {
+        sectionRepository.delete(section);
+    }
 }

--- a/src/main/java/nextstep/subway/section/domain/Section.java
+++ b/src/main/java/nextstep/subway/section/domain/Section.java
@@ -95,8 +95,16 @@ public class Section extends BaseEntity {
     }
 
     public void mergeDownStation(Section section) {
+        validateMergeAble(this, section);
         this.distance += section.distance;
         this.downStation = section.downStation;
+        validateStations();
+    }
+
+    private void validateMergeAble(Section up, Section down) {
+        if (!up.downStation.equals(down.upStation)) {
+            throw new IllegalArgumentException("병합하고자 하는 구간의 상행역과 현재 구간의 하행역이 동일해야 합니다.");
+        }
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/section/domain/Section.java
+++ b/src/main/java/nextstep/subway/section/domain/Section.java
@@ -94,6 +94,11 @@ public class Section extends BaseEntity {
         this.sequence = sequence;
     }
 
+    public void mergeDownStation(Section section) {
+        this.distance += section.distance;
+        this.downStation = section.downStation;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/section/domain/Section.java
+++ b/src/main/java/nextstep/subway/section/domain/Section.java
@@ -101,6 +101,13 @@ public class Section extends BaseEntity {
         validateStations();
     }
 
+    public void mergeUpStation(Section section) {
+        validateMergeAble(section, this);
+        this.distance += section.distance;
+        this.upStation = section.upStation;
+        validateStations();
+    }
+
     private void validateMergeAble(Section up, Section down) {
         if (!up.downStation.equals(down.upStation)) {
             throw new IllegalArgumentException("병합하고자 하는 구간의 상행역과 현재 구간의 하행역이 동일해야 합니다.");

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -36,6 +36,14 @@ public class Sections implements Iterable<Section> {
         return sections.get(lastIndex()).getUpStation();
     }
 
+    private boolean isFirstStop(Station station) {
+        return getFirstStation().equals(station);
+    }
+
+    private boolean isLastStop(Station station) {
+        return getLastStation().equals(station);
+    }
+
     private int lastIndex() {
         return sections.size() - 1;
     }
@@ -84,13 +92,13 @@ public class Sections implements Iterable<Section> {
     }
 
     private int selectDivisionIndex(Section element) {
-        if (getFirstStation().equals(element.getUpStation())) {
+        if (isFirstStop(element.getUpStation())) {
             return FRONT_OF_SECTIONS;
         }
-        if (getLastStation().equals(element.getUpStation())) {
+        if (isLastStop(element.getUpStation())) {
             return lastIndex();
         }
-        if (getLastStation().equals(element.getDownStation())) {
+        if (isLastStop(element.getDownStation())) {
             return sections.size();
         }
         if (getUpStations().contains(element.getDownStation())) {
@@ -150,10 +158,10 @@ public class Sections implements Iterable<Section> {
     }
 
     private Section selectRemoveTarget(Station element) {
-        if (getFirstStation().equals(element)) {
+        if (isFirstStop(element)) {
             return sections.get(FIRST_INDEX);
         }
-        if (getLastStation().equals(element)) {
+        if (isLastStop(element)) {
             return sections.get(lastIndex());
         }
         int index = getDownStations().indexOf(element);
@@ -170,7 +178,7 @@ public class Sections implements Iterable<Section> {
     }
 
     private boolean isEdge(Station station) {
-        return getFirstStation().equals(station) || getLastStation().equals(station);
+        return isFirstStop(station) || isLastStop(station);
     }
 
     private void remove(Section section) {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -66,27 +66,12 @@ public class Sections implements Iterable<Section> {
         synchronizeSequence();
     }
 
-    public void removeStation(Station element) {
-        validateRemovable(element);
-        remove(selectRemoveIndex(element), element);
-        synchronizeSequence();
-    }
-
     private void validateAddable(Section section) {
         if (isStationAllContains(section)) {
             throw new IllegalArgumentException("구간에 속한 모든 역이 노선에 포함되어 있습니다. 역 정보를 확인해주세요.");
         }
         if (isStationNotContains(section)) {
             throw new IllegalArgumentException("구간에 속한 모든 역이 노선에 포함되어 있지 않습니다. 역 정보를 확인해주세요.");
-        }
-    }
-
-    private void validateRemovable(Station element) {
-        if (sections.size() == 1) {
-            throw new IllegalStateException("구간은 최소 한 개 이상 존재해야 합니다.");
-        }
-        if (!getStations().contains(element)) {
-            throw new IllegalArgumentException("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
         }
     }
 
@@ -114,33 +99,15 @@ public class Sections implements Iterable<Section> {
         return getDownStations().indexOf(element.getUpStation()) - 1;
     }
 
-    private int selectRemoveIndex(Station element) {
-        if (getFirstStation().equals(element)) {
-            return FRONT_OF_SECTIONS;
-        }
-        if (getLastStation().equals(element)) {
-            return sections.size();
-        }
-        return getUpStations().indexOf(element);
-    }
-
     private void add(int index, Section element) {
-        if (isEdge(index)) {
+        if (isOutOfEdge(index)) {
             addEdge(index, element);
             return;
         }
         divideSection(index, element);
     }
 
-    private void remove(int index, Station station) {
-        if (isEdge(index)) {
-            removeEdge(index);
-            return;
-        }
-        mergeSection(index, station);
-    }
-
-    private boolean isEdge(int index) {
+    private boolean isOutOfEdge(int index) {
         return index == FRONT_OF_SECTIONS || index == sections.size();
     }
 
@@ -150,14 +117,6 @@ public class Sections implements Iterable<Section> {
             return;
         }
         sections.add(index, element);
-    }
-
-    private void removeEdge(int index) {
-        if (index == FRONT_OF_SECTIONS) {
-            sections.remove(FIRST_INDEX);
-            return;
-        }
-        sections.remove(lastIndex());
     }
 
     private void divideSection(int index, Section element) {
@@ -173,11 +132,52 @@ public class Sections implements Iterable<Section> {
         }
     }
 
-    private void mergeSection(int index, Station station) {
+    public void removeStation(Station element) {
+        validateRemovable(element);
+        removeStation(selectRemoveIndex(element));
+    }
+
+    private void validateRemovable(Station element) {
+        if (sections.size() == 1) {
+            throw new IllegalStateException("구간은 최소 한 개 이상 존재해야 합니다.");
+        }
+        if (!getStations().contains(element)) {
+            throw new IllegalArgumentException("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
+        }
+    }
+
+    private int selectRemoveIndex(Station element) {
+        if (getFirstStation().equals(element)) {
+            return FIRST_INDEX;
+        }
+        if (getLastStation().equals(element)) {
+            return lastIndex();
+        }
+        return getDownStations().indexOf(element);
+    }
+
+    private void removeStation(int index) {
+        if (isEdge(index)) {
+            remove(index);
+            return;
+        }
+        mergeSection(index);
+    }
+
+    private boolean isEdge(int index) {
+        return index == FIRST_INDEX || index == lastIndex();
+    }
+
+    private void mergeSection(int index) {
         Section removeTarget = sections.get(index);
-        Section mergeTarget = sections.get(index + 1);
-        mergeTarget.mergeDownStation(removeTarget);
+        Section mergeTarget = sections.get(index - 1);
+        mergeTarget.mergeUpStation(removeTarget);
+        remove(index);
+    }
+
+    private void remove(int index) {
         sections.remove(index);
+        synchronizeSequence();
     }
 
     private void synchronizeSequence() {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -66,6 +66,10 @@ public class Sections implements Iterable<Section> {
         synchronizeSequence();
     }
 
+    public void removeStation(Station element) {
+        validateRemovable(element);
+    }
+
     private void validateAddable(Section section) {
         if (isStationAllContains(section)) {
             throw new IllegalArgumentException("구간에 속한 모든 역이 노선에 포함되어 있습니다. 역 정보를 확인해주세요.");
@@ -97,6 +101,15 @@ public class Sections implements Iterable<Section> {
             return getUpStations().indexOf(element.getDownStation()) + 1;
         }
         return getDownStations().indexOf(element.getUpStation()) - 1;
+    }
+
+    private void validateRemovable(Station element) {
+        if (sections.size() == 1) {
+            throw new IllegalStateException("구간은 최소 한 개 이상 존재해야 합니다.");
+        }
+        if (!getStations().contains(element)) {
+            throw new IllegalArgumentException("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
+        }
     }
 
     private void add(int index, Section element) {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -132,9 +132,11 @@ public class Sections implements Iterable<Section> {
         }
     }
 
-    public void removeStation(Station element) {
+    public Section remove(Station element) {
         validateRemovable(element);
-        removeStation(selectRemoveIndex(element));
+        Section removeTarget = selectRemoveTarget(element);
+        remove(removeTarget);
+        return removeTarget;
     }
 
     private void validateRemovable(Station element) {
@@ -146,38 +148,35 @@ public class Sections implements Iterable<Section> {
         }
     }
 
-    private int selectRemoveIndex(Station element) {
+    private Section selectRemoveTarget(Station element) {
         if (getFirstStation().equals(element)) {
-            return FIRST_INDEX;
+            return sections.get(FIRST_INDEX);
         }
         if (getLastStation().equals(element)) {
-            return lastIndex();
+            return sections.get(lastIndex());
         }
-        return getDownStations().indexOf(element);
+        int index = getDownStations().indexOf(element);
+        return sections.get(index);
     }
 
-    private void removeStation(int index) {
-        if (isEdge(index)) {
-            remove(index);
+    private void remove(Section section) {
+        mergeSection(section);
+        sections.remove(section);
+        synchronizeSequence();
+    }
+
+    private void mergeSection(Section removeTarget) {
+        if (isEdge(removeTarget)) {
             return;
         }
-        mergeSection(index);
-    }
-
-    private boolean isEdge(int index) {
-        return index == FIRST_INDEX || index == lastIndex();
-    }
-
-    private void mergeSection(int index) {
-        Section removeTarget = sections.get(index);
-        Section mergeTarget = sections.get(index - 1);
+        int removeIndex = sections.indexOf(removeTarget);
+        Section mergeTarget = sections.get(removeIndex - 1);
         mergeTarget.mergeUpStation(removeTarget);
-        remove(index);
     }
 
-    private void remove(int index) {
-        sections.remove(index);
-        synchronizeSequence();
+    private boolean isEdge(Section section) {
+        int index = sections.indexOf(section);
+        return index == FIRST_INDEX || index == lastIndex();
     }
 
     private void synchronizeSequence() {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -132,9 +132,10 @@ public class Sections implements Iterable<Section> {
         }
     }
 
-    public Section remove(Station element) {
-        validateRemovable(element);
-        Section removeTarget = selectRemoveTarget(element);
+    public Section remove(Station station) {
+        validateRemovable(station);
+        Section removeTarget = selectRemoveTarget(station);
+        mergeSection(removeTarget, station);
         remove(removeTarget);
         return removeTarget;
     }
@@ -159,14 +160,8 @@ public class Sections implements Iterable<Section> {
         return sections.get(index);
     }
 
-    private void remove(Section section) {
-        mergeSection(section);
-        sections.remove(section);
-        synchronizeSequence();
-    }
-
-    private void mergeSection(Section removeTarget) {
-        if (isEdge(removeTarget)) {
+    private void mergeSection(Section removeTarget, Station station) {
+        if (isEdge(station)) {
             return;
         }
         int removeIndex = sections.indexOf(removeTarget);
@@ -174,9 +169,13 @@ public class Sections implements Iterable<Section> {
         mergeTarget.mergeUpStation(removeTarget);
     }
 
-    private boolean isEdge(Section section) {
-        int index = sections.indexOf(section);
-        return index == FIRST_INDEX || index == lastIndex();
+    private boolean isEdge(Station station) {
+        return getFirstStation().equals(station) || getLastStation().equals(station);
+    }
+
+    private void remove(Section section) {
+        sections.remove(section);
+        synchronizeSequence();
     }
 
     private void synchronizeSequence() {

--- a/src/test/java/nextstep/subway/RestAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/RestAcceptanceTest.java
@@ -45,4 +45,14 @@ public class RestAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
     }
+
+    protected static ExtractableResponse<Response> executeDelete(String path, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete(path)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/nextstep/subway/RestAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/RestAcceptanceTest.java
@@ -45,14 +45,4 @@ public class RestAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
     }
-
-    protected static ExtractableResponse<Response> executeDelete(String path, Map<String, String> params) {
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .delete(path)
-                .then().log().all()
-                .extract();
-    }
 }

--- a/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
@@ -144,8 +144,6 @@ public class SectionAcceptanceTest extends RestAcceptanceTest {
     }
 
     public static ExtractableResponse<Response> removeSectionByStationId(Long lineId, Long stationId) {
-        Map<String, String> params = new HashMap<>();
-        params.put("stationId", stationId.toString());
-        return executeDelete("lines/" + lineId.toString() + "/sections", params);
+        return executeDelete("lines/" + lineId.toString() + "/sections?stationId=" + stationId.toString());
     }
 }

--- a/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
@@ -75,11 +75,77 @@ public class SectionAcceptanceTest extends RestAcceptanceTest {
         assertThat(expected.getStations().get(expected.getStations().size() - 1).getName()).isEqualTo(lastStop.getName());
     }
 
+    @DisplayName("구간에서 역 제거 - 시착역 제거")
+    @Test
+    void removeStation_firstStop() {
+        // given
+        LineResponse lineResponse = LineAcceptanceTest.saveShinBundangLine().jsonPath().getObject(".", LineResponse.class);
+        StationResponse stationResponse = StationAcceptanceTest.saveStation("양재").jsonPath().getObject(".", StationResponse.class);
+        StationResponse firstStop = lineResponse.getStations().get(0);
+        StationResponse lastStop = lineResponse.getStations().get(lineResponse.getStations().size() - 1);
+        saveSection(lineResponse.getId(), lastStop.getId(), stationResponse.getId(), 5);
+
+        // when
+        removeSectionByStationId(lineResponse.getId(), firstStop.getId());
+        LineResponse expected = LineAcceptanceTest.findLine(lineResponse.getId()).jsonPath().getObject(".", LineResponse.class);
+
+        // then
+        assertThat(expected.getStations().size()).isEqualTo(2);
+        assertThat(expected.getStations().get(0).getName()).isEqualTo(stationResponse.getName());
+        assertThat(expected.getStations().get(expected.getStations().size() - 1).getName()).isEqualTo(lastStop.getName());
+    }
+
+    @DisplayName("구간에서 역 제거 - 종착역 제거")
+    @Test
+    void removeStation_lastStop() {
+        // given
+        LineResponse lineResponse = LineAcceptanceTest.saveShinBundangLine().jsonPath().getObject(".", LineResponse.class);
+        StationResponse stationResponse = StationAcceptanceTest.saveStation("양재").jsonPath().getObject(".", StationResponse.class);
+        StationResponse firstStop = lineResponse.getStations().get(0);
+        StationResponse lastStop = lineResponse.getStations().get(lineResponse.getStations().size() - 1);
+        saveSection(lineResponse.getId(), lastStop.getId(), stationResponse.getId(), 5);
+
+        // when
+        removeSectionByStationId(lineResponse.getId(), lastStop.getId());
+        LineResponse expected = LineAcceptanceTest.findLine(lineResponse.getId()).jsonPath().getObject(".", LineResponse.class);
+
+        // then
+        assertThat(expected.getStations().size()).isEqualTo(2);
+        assertThat(expected.getStations().get(0).getName()).isEqualTo(firstStop.getName());
+        assertThat(expected.getStations().get(expected.getStations().size() - 1).getName()).isEqualTo(stationResponse.getName());
+    }
+
+    @DisplayName("구간에서 역 제거 - 중간역 제거")
+    @Test
+    void removeStation_middleStop() {
+        // given
+        LineResponse lineResponse = LineAcceptanceTest.saveShinBundangLine().jsonPath().getObject(".", LineResponse.class);
+        StationResponse stationResponse = StationAcceptanceTest.saveStation("양재").jsonPath().getObject(".", StationResponse.class);
+        StationResponse firstStop = lineResponse.getStations().get(0);
+        StationResponse lastStop = lineResponse.getStations().get(lineResponse.getStations().size() - 1);
+        saveSection(lineResponse.getId(), lastStop.getId(), stationResponse.getId(), 5);
+
+        // when
+        removeSectionByStationId(lineResponse.getId(), stationResponse.getId());
+        LineResponse expected = LineAcceptanceTest.findLine(lineResponse.getId()).jsonPath().getObject(".", LineResponse.class);
+
+        // then
+        assertThat(expected.getStations().size()).isEqualTo(2);
+        assertThat(expected.getStations().get(0).getName()).isEqualTo(firstStop.getName());
+        assertThat(expected.getStations().get(expected.getStations().size() - 1).getName()).isEqualTo(lastStop.getName());
+    }
+
     public static ExtractableResponse<Response> saveSection(Long lineId, Long upStationId, Long downStationId, int distance) {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId.toString());
         params.put("downStationId", downStationId.toString());
         params.put("distance", String.valueOf(distance));
         return executePost("lines/" + lineId.toString() + "/sections", params);
+    }
+
+    public static ExtractableResponse<Response> removeSectionByStationId(Long lineId, Long stationId) {
+        Map<String, String> params = new HashMap<>();
+        params.put("stationId", stationId.toString());
+        return executeDelete("lines/" + lineId.toString() + "/sections", params);
     }
 }

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -356,6 +356,7 @@ class SectionRepositoryTest {
     }
     
     @DisplayName("병합가능여부 검증 - 병합 후 구간의 상 하행역은 동일할 수 없음")
+    @Test
     void validateMergeAble_upAndDownStationAreSame() {
         // given
         Station station1 = saveStation("정자");
@@ -365,7 +366,7 @@ class SectionRepositoryTest {
         Section up = saveSection(station1, station2, 20);
 
         // when then
-        assertThatIllegalArgumentException()
+        assertThatIllegalStateException()
                 .isThrownBy(() -> up.mergeDownStation(down))
                 .withMessageMatching("상행역과 하행역은 동일할 수 없습니다.");
     }

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -286,7 +286,7 @@ class SectionRepositoryTest {
 
         // when then
         assertThatIllegalStateException()
-                .isThrownBy(() -> sections.removeStation(station1))
+                .isThrownBy(() -> sections.remove(station1))
                 .withMessageMatching("구간은 최소 한 개 이상 존재해야 합니다.");
     }
 
@@ -313,7 +313,7 @@ class SectionRepositoryTest {
 
         // then
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> sections.removeStation(station5))
+                .isThrownBy(() -> sections.remove(station5))
                 .withMessageMatching("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
     }
 
@@ -390,7 +390,7 @@ class SectionRepositoryTest {
         sections.add(section3);
 
         // when
-        sections.removeStation(station1);
+        sections.remove(station1);
 
         // then
         List<String> stationNames = sections.getStations().stream()
@@ -419,7 +419,7 @@ class SectionRepositoryTest {
         sections.add(section3);
 
         // when
-        sections.removeStation(station4);
+        sections.remove(station4);
 
         // then
         List<String> stationNames = sections.getStations().stream()
@@ -448,7 +448,7 @@ class SectionRepositoryTest {
         sections.add(section3);
 
         // when
-        sections.removeStation(station2);
+        sections.remove(station2);
 
         // then
         List<String> stationNames = sections.getStations().stream()

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -325,15 +325,49 @@ class SectionRepositoryTest {
         Station station2 = saveStation("판교");
         Station station3 = saveStation("양재");
 
-        Section section1 = saveSection(station2, station1, 5);
-        Section section2 = saveSection(station3, station2, 20);
+        Section down = saveSection(station2, station1, 5);
+        Section up = saveSection(station3, station2, 20);
 
         // when
-        section2.mergeDownStation(section1);
+        up.mergeDownStation(down);
 
         // then
-        assertThat(section2.getUpStation()).isSameAs(station3);
-        assertThat(section2.getDownStation()).isSameAs(station1);
+        assertThat(up.getUpStation()).isSameAs(station3);
+        assertThat(up.getDownStation()).isSameAs(station1);
+    }
+
+    @DisplayName("병합가능여부 검증 - 병합하고자 하는 구간의 상행역과 현재 구간의 하행역이 동일해야 함")
+    @Test
+    void validateMergeAble() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+
+        Station station4 = saveStation("광교");
+
+        Section down = saveSection(station4, station1, 5);
+        Section up = saveSection(station3, station2, 20);
+
+        // when then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> up.mergeDownStation(down))
+                .withMessageMatching("병합하고자 하는 구간의 상행역과 현재 구간의 하행역이 동일해야 합니다.");
+    }
+    
+    @DisplayName("병합가능여부 검증 - 병합 후 구간의 상 하행역은 동일할 수 없음")
+    void validateMergeAble_upAndDownStationAreSame() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+
+        Section down = saveSection(station2, station1, 5);
+        Section up = saveSection(station1, station2, 20);
+
+        // when then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> up.mergeDownStation(down))
+                .withMessageMatching("상행역과 하행역은 동일할 수 없습니다.");
     }
 
     private Section saveSection(Station upStation, Station downStation, int distance) {

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -371,6 +371,93 @@ class SectionRepositoryTest {
                 .withMessageMatching("상행역과 하행역은 동일할 수 없습니다.");
     }
 
+    @DisplayName("역 제거 - 시착역 제거")
+    @Test
+    void removeStation_firstStop() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+        Station station4 = saveStation("강남");
+
+        Section section1 = saveSection(station2, station1, 5);
+        Section section2 = saveSection(station3, station2, 20);
+        Section section3 = saveSection(station4, station3, 7);
+
+        Sections sections = new Sections();
+        sections.add(section1);
+        sections.add(section2);
+        sections.add(section3);
+
+        // when
+        sections.removeStation(station1);
+
+        // then
+        List<String> stationNames = sections.getStations().stream()
+                .map(Station::getName)
+                .collect(Collectors.toList());
+        assertThat(stationNames.size()).isEqualTo(3);
+        assertThat(stationNames).isEqualTo(Arrays.asList("판교", "양재", "강남"));
+    }
+
+    @DisplayName("역 제거 - 종착역 제거")
+    @Test
+    void removeStation_lastStop() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+        Station station4 = saveStation("강남");
+
+        Section section1 = saveSection(station2, station1, 5);
+        Section section2 = saveSection(station3, station2, 20);
+        Section section3 = saveSection(station4, station3, 7);
+
+        Sections sections = new Sections();
+        sections.add(section1);
+        sections.add(section2);
+        sections.add(section3);
+
+        // when
+        sections.removeStation(station4);
+
+        // then
+        List<String> stationNames = sections.getStations().stream()
+                .map(Station::getName)
+                .collect(Collectors.toList());
+        assertThat(stationNames.size()).isEqualTo(3);
+        assertThat(stationNames).isEqualTo(Arrays.asList("정자", "판교", "양재"));
+    }
+
+    @DisplayName("역 제거 - 중간역 제거")
+    @Test
+    void removeStation_middle() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+        Station station4 = saveStation("강남");
+
+        Section section1 = saveSection(station2, station1, 5);
+        Section section2 = saveSection(station3, station2, 20);
+        Section section3 = saveSection(station4, station3, 7);
+
+        Sections sections = new Sections();
+        sections.add(section1);
+        sections.add(section2);
+        sections.add(section3);
+
+        // when
+        sections.removeStation(station2);
+
+        // then
+        List<String> stationNames = sections.getStations().stream()
+                .map(Station::getName)
+                .collect(Collectors.toList());
+        assertThat(stationNames.size()).isEqualTo(3);
+        assertThat(stationNames).isEqualTo(Arrays.asList("정자", "양재", "강남"));
+    }
+
     private Section saveSection(Station upStation, Station downStation, int distance) {
         Section section = Section.of(upStation, downStation, distance);
         return sectionRepository.save(section);

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -15,8 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
 class SectionRepositoryTest {
@@ -273,6 +272,22 @@ class SectionRepositoryTest {
                 .collect(Collectors.toList());
         assertThat(stationNames.size()).isEqualTo(5);
         assertThat(stationNames).isEqualTo(Arrays.asList("정자", "판교", "청계산입구", "양재", "강남"));
+    }
+
+    @DisplayName("역 제거 검증 - 구간이 하나만 존재하는 경우")
+    @Test
+    void removeStation_sizeIsOne() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Section section = saveSection(station2, station1, 5);
+        Sections sections = new Sections();
+        sections.add(section);
+
+        // when then
+        assertThatIllegalStateException()
+                .isThrownBy(() -> sections.removeStation(station1))
+                .withMessageMatching("구간은 최소 한 개 이상 존재해야 합니다.");
     }
 
     private Section saveSection(Station upStation, Station downStation, int distance) {

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -317,6 +317,25 @@ class SectionRepositoryTest {
                 .withMessageMatching("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
     }
 
+    @DisplayName("구간 병합 - 하행선 추가")
+    @Test
+    void mergeDownStation() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+
+        Section section1 = saveSection(station2, station1, 5);
+        Section section2 = saveSection(station3, station2, 20);
+
+        // when
+        section2.mergeDownStation(section1);
+
+        // then
+        assertThat(section2.getUpStation()).isSameAs(station3);
+        assertThat(section2.getDownStation()).isSameAs(station1);
+    }
+
     private Section saveSection(Station upStation, Station downStation, int distance) {
         Section section = Section.of(upStation, downStation, distance);
         return sectionRepository.save(section);

--- a/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionRepositoryTest.java
@@ -290,6 +290,33 @@ class SectionRepositoryTest {
                 .withMessageMatching("구간은 최소 한 개 이상 존재해야 합니다.");
     }
 
+    @DisplayName("역 제거 검증 - 구간에 존재하지 않는 역 제거")
+    @Test
+    void removeStation_stationIsNotExist() {
+        // given
+        Station station1 = saveStation("정자");
+        Station station2 = saveStation("판교");
+        Station station3 = saveStation("양재");
+        Station station4 = saveStation("강남");
+
+        Section section1 = saveSection(station2, station1, 5);
+        Section section2 = saveSection(station3, station2, 20);
+        Section section3 = saveSection(station4, station3, 7);
+
+        Sections sections = new Sections();
+        sections.add(section1);
+        sections.add(section2);
+        sections.add(section3);
+
+        // when
+        Station station5 = saveStation("청계산입구");
+
+        // then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> sections.removeStation(station5))
+                .withMessageMatching("삭제하고자 하는 역 정보가 존재하지 않습니다. 입력정보를 확인해주세요.");
+    }
+
     private Section saveSection(Station upStation, Station downStation, int distance) {
         Section section = Section.of(upStation, downStation, distance);
         return sectionRepository.save(section);


### PR DESCRIPTION
영재님 안녕하세요!
4단계 구간제거기능 구현 완료하여 리뷰 요청 드립니다!😄

3단계의 구간 추가를 반대로 생각하면 되겠지 하는 생각으로 접근했다가...😅
역을 제거하는 개념과, 구간을 제거하는 개념을 혼동해서 중간에 삽을 많이 팠네요😭

아 그리고 질문이 하나 있습니다!
저번 미션에서 @orderby("sequence ASC") 어노테이션 사용에 대해
'항상 order를 일정하게 준다는 제약이 생김으로 개인적인 생각으로는 쿼리에서 처리하도록 유도할 수 있다'
라는 코멘트를 주셨는데요! 제가 JPA 사용 경험이 없어서 그런지 해당 가이드에 대한 이해가 부족한 것 같습니다😅

구간정보는 항상 정렬되어 있어야 비즈니스 로직 처리에 문제가 생기지 않기 때문에, 일급컬렉션 초기화 시점부터
정렬이 필요하다는 생각이 드는데요! 영재님께서 말씀주신 '쿼리에서 처리한다' 라는 내용이
엔티티 객체를 초기화하는 시점에 시퀀스 값을 기반으로 정렬 조회 처리가 가능한 특정 쿼리를 호출한다는 말씀이셨을까요?!

제 질문이 부자연스러운 것인가 싶기도 합니다😅
여유있으실 때 한 번 봐주시면 감사하겠습니다!
그럼 오늘도 즐거운 하루 보내세요~!