### PR TITLE
Step4 - ATDD (구간 제거 기능) 리뷰 요청드립니다.

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -11,6 +11,7 @@ import nextstep.subway.section.domain.Section;
 import nextstep.subway.section.domain.SectionRepository;
 import nextstep.subway.section.dto.SectionRequest;
 import nextstep.subway.section.dto.SectionResponse;
+import nextstep.subway.station.domain.Station;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,5 +67,10 @@ public class LineService {
     public List<SectionResponse> findAllSections(Long lineId) {
         Line line = lineRepository.findById(lineId).orElseThrow(EntityNotFoundException::new);
         return SectionResponse.toSectionResponses(line.getSections());
+    }
+
+    public void deleteStation(Long lineId, Long stationId) {
+        Line line = lineRepository.findById(lineId).orElseThrow(EntityNotFoundException::new);
+        line.deleteStation(new Station(stationId));
     }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -65,6 +65,6 @@ public class LineService {
 
     public List<SectionResponse> findAllSections(Long lineId) {
         Line line = lineRepository.findById(lineId).orElseThrow(EntityNotFoundException::new);
-        return line.getSections().toSectionResponses();
+        return SectionResponse.toSectionResponses(line.getSections());
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import nextstep.subway.common.BaseEntity;
 import nextstep.subway.section.domain.Section;
 import nextstep.subway.section.domain.Sections;
+import nextstep.subway.station.domain.Station;
 
 @Entity
 public class Line extends BaseEntity {
@@ -67,5 +68,9 @@ public class Line extends BaseEntity {
 
     public String getColor() {
         return color;
+    }
+
+    public void deleteStation(Station station) {
+        sections.delete(station);
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -67,6 +68,12 @@ public class LineController {
     @GetMapping("/{lineId}/sections")
     public ResponseEntity<List<SectionResponse>> showSections(@PathVariable Long lineId) {
         return ResponseEntity.ok().body(lineService.findAllSections(lineId));
+    }
+
+    @DeleteMapping("/{lineId}/sections")
+    public ResponseEntity<Void> deleteLineStation(@PathVariable Long lineId, @RequestParam("stationId") Long stationId) {
+        lineService.deleteStation(lineId, stationId);
+        return ResponseEntity.noContent().build();
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)

--- a/src/main/java/nextstep/subway/section/domain/Section.java
+++ b/src/main/java/nextstep/subway/section/domain/Section.java
@@ -111,30 +111,21 @@ public class Section extends BaseEntity {
         if (!upStation.equals(section.getUpStation())) {
             return false;
         }
-        if (!downStation.equals(section.getDownStation())) {
-            return false;
-        }
-        return true;
+        return downStation.equals(section.getDownStation());
     }
 
     protected boolean isPresentAnyStation(Section section) {
         if (contain(section.getUpStation())) {
             return true;
         }
-        if (contain(section.getDownStation())) {
-            return true;
-        }
-        return false;
+        return contain(section.getDownStation());
     }
 
-    private boolean contain(Station station) {
+    protected boolean contain(Station station) {
         if (upStation.equals(station)) {
             return true;
         }
-        if (downStation.equals(station)) {
-            return true;
-        }
-        return false;
+        return downStation.equals(station);
     }
 
     protected void updateUpStationTo(Station newStation) {
@@ -143,6 +134,10 @@ public class Section extends BaseEntity {
 
     protected void updateDownStationTo(Station newStation) {
         downStation = newStation;
+    }
+
+    protected void plusDistance(int distance) {
+        this.distance += distance;
     }
 
     protected void minusDistance(int distance) {

--- a/src/main/java/nextstep/subway/section/domain/Section.java
+++ b/src/main/java/nextstep/subway/section/domain/Section.java
@@ -157,7 +157,7 @@ public class Section extends BaseEntity {
     }
 
     private void validationDistance(int distance) {
-        if (distance == MIN_DISTANCE) {
+        if (distance <= MIN_DISTANCE) {
             throw new IllegalArgumentException(String.format(DISTANCE_MUST_BE_AT_LEAST_MIN_DISTANCE, MIN_DISTANCE));
         }
     }

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -19,7 +19,7 @@ public class Sections {
     public static final String SECTION_ALREADY_EXISTS = "이미 상행역과 하행역으로 연결되는 구간이 등록되어 있습니다.";
     public static final String THERE_IS_NO_STATION_INCLUDED_BETWEEN_UP_AND_DOWN_STATIONS = "상행역과 하행역 둘중 포함되는 역이 없습니다.";
     public static final int ONE = 1;
-    public static final boolean EMPTY_UPSTATION = false;
+    public static final boolean NOT_EXIST_UPSTATION = false;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "line", cascade = CascadeType.ALL)
     private List<Section> sections;
@@ -102,13 +102,15 @@ public class Sections {
 
     private Section findFirstSection() {
         Map<Boolean, Section> map = new HashMap<>();
-        sections.forEach(current -> {
-            Optional<Section> optional = sections.stream()
-                .filter(section -> section.isBefore(current))
-                .findFirst();
-            map.put(optional.isPresent(), current);
+        sections.forEach(section -> {
+            map.put(existUpStation(section), section);
         });
-        return map.get(EMPTY_UPSTATION);
+        return map.get(NOT_EXIST_UPSTATION);
+    }
+
+    private boolean existUpStation(Section destSection) {
+        return sections.stream()
+            .anyMatch(section -> section.isBefore(destSection));
     }
 
     private List<Station> getUpStations(List<Section> sections) {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -75,14 +75,12 @@ public class Sections {
 
     private boolean isPresent(Section section) {
         return sections.stream()
-            .filter(s -> s.isEqualAllStation(section))
-            .findFirst().isPresent();
+            .anyMatch(s -> s.isEqualAllStation(section));
     }
 
     private boolean isPresentAnyStation(Section section) {
         return sections.stream()
-            .filter(s -> s.isPresentAnyStation(section))
-            .findFirst().isPresent();
+            .anyMatch(s -> s.isPresentAnyStation(section));
     }
 
     public List<Station> findStationsInOrder() {

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -9,6 +9,8 @@ import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
+import nextstep.subway.section.exception.NotExistStationOnLineException;
+import nextstep.subway.section.exception.OnlyOneSectionExistException;
 import nextstep.subway.station.domain.Station;
 
 @Embeddable
@@ -17,10 +19,10 @@ public class Sections {
     public static final String SECTIONS_CANNOT_BE_NULL = "구간목록은 NULL이 될수 없습니다.";
     public static final String SECTION_ALREADY_EXISTS = "이미 상행역과 하행역으로 연결되는 구간이 등록되어 있습니다.";
     public static final String THERE_IS_NO_STATION_INCLUDED_BETWEEN_UP_AND_DOWN_STATIONS = "상행역과 하행역 둘중 포함되는 역이 없습니다.";
+    public static final int ZERO = 0;
     public static final int ONE = 1;
-    public static final boolean NOT_EXIST_UPSTATION = false;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "line", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Section> sections;
 
     public Sections() {
@@ -132,5 +134,60 @@ public class Sections {
 
     public List<Section> getSections() {
         return sections;
+    }
+
+    public void delete(Station station) {
+        validationNotExistStationOnLine(station);
+        validationOnlyOneSectionExists();
+
+        List<Section> foundSections = findSectionsContainStation(station);
+        if (foundSections.size() == ONE) {
+            sections.remove(foundSections.get(ZERO));
+        }
+        if (foundSections.size() > ONE) {
+            deleteMiddleStation(foundSections, station);
+        }
+    }
+
+    private void validationOnlyOneSectionExists() {
+        if (sections.size() == ONE) {
+            throw new OnlyOneSectionExistException();
+        }
+    }
+
+    private void validationNotExistStationOnLine(Station station) {
+        sections.stream()
+            .filter(section -> section.contain(station))
+            .findFirst().orElseThrow(NotExistStationOnLineException::new);
+    }
+
+    private List<Section> findSectionsContainStation(Station station) {
+        return sections.stream()
+            .filter(section -> section.contain(station))
+            .collect(Collectors.toList());
+    }
+
+    private void deleteMiddleStation(List<Section> foundSections, Station station) {
+        Optional<Section> updateSectionOptional = findUpdateSection(foundSections, station);
+        Optional<Section> removeSectionOptional = findRemoveSection(foundSections, station);
+        if (updateSectionOptional.isPresent() && removeSectionOptional.isPresent()) {
+            Section updateSection = updateSectionOptional.get();
+            Section removeSection = removeSectionOptional.get();
+            updateSection.updateDownStationTo(removeSection.getDownStation());
+            updateSection.plusDistance(removeSection.getDistance());
+            sections.remove(removeSection);
+        }
+    }
+
+    private Optional<Section> findUpdateSection(List<Section> foundSections, Station station) {
+        return foundSections.stream()
+            .filter(section -> station.equals(section.getDownStation()))
+            .findFirst();
+    }
+
+    private Optional<Section> findRemoveSection(List<Section> foundSections, Station station) {
+        return foundSections.stream()
+            .filter(section -> station.equals(section.getUpStation()))
+            .findFirst();
     }
 }

--- a/src/main/java/nextstep/subway/section/domain/Sections.java
+++ b/src/main/java/nextstep/subway/section/domain/Sections.java
@@ -10,7 +10,6 @@ import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
-import nextstep.subway.section.dto.SectionResponse;
 import nextstep.subway.station.domain.Station;
 
 @Embeddable
@@ -124,9 +123,7 @@ public class Sections {
         return sections.get(sections.size() - ONE).getDownStation();
     }
 
-    public List<SectionResponse> toSectionResponses() {
-        return sections.stream()
-            .map(SectionResponse::of)
-            .collect(Collectors.toList());
+    public List<Section> getSections() {
+        return sections;
     }
 }

--- a/src/main/java/nextstep/subway/section/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/section/dto/SectionResponse.java
@@ -1,7 +1,10 @@
 package nextstep.subway.section.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import nextstep.subway.section.domain.Section;
+import nextstep.subway.section.domain.Sections;
 
 public class SectionResponse {
 
@@ -57,6 +60,13 @@ public class SectionResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public static List<SectionResponse> toSectionResponses(Sections sections) {
+        return sections.getSections()
+            .stream()
+            .map(SectionResponse::of)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/nextstep/subway/section/exception/NotExistStationOnLineException.java
+++ b/src/main/java/nextstep/subway/section/exception/NotExistStationOnLineException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.section.exception;
+
+public class NotExistStationOnLineException extends RuntimeException {
+
+    public NotExistStationOnLineException() {
+        super("해당 노선에 삭제하려는 역이 등록되어 있지 않습니다.");
+    }
+}

--- a/src/main/java/nextstep/subway/section/exception/OnlyOneSectionExistException.java
+++ b/src/main/java/nextstep/subway/section/exception/OnlyOneSectionExistException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.section.exception;
+
+public class OnlyOneSectionExistException extends RuntimeException {
+
+    public OnlyOneSectionExistException() {
+        super("해당 노선의 구간이 1개만 남아 있어서 해당역을 삭제하실 수 없습니다.");
+    }
+}

--- a/src/test/java/nextstep/subway/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/AcceptanceTest.java
@@ -1,5 +1,7 @@
 package nextstep.subway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -61,5 +64,8 @@ public class AcceptanceTest {
             .delete(uri)
             .then().log().all()
             .extract();
+    }
+    public void assertResponseCode(ExtractableResponse<Response> response, HttpStatus httpStatus) {
+        assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 }

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.dto.LineResponse;
@@ -48,7 +49,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_등록되어_있음_두_종점역_포함(line5, new Section(aeogaeStation, gwanghwamunStation, 10));
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertResponseCode(response, HttpStatus.CREATED);
         assertThat(response.jsonPath().getString("name")).isEqualTo(line5.getName());
         assertThat(response.jsonPath().getString("color")).isEqualTo(line5.getColor());
     }
@@ -63,7 +64,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_등록되어_있음_두_종점역_포함(line5, new Section(aeogaeStation, gwanghwamunStation, 10));
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("지하철 노선 목록을 조회한다.")
@@ -79,12 +80,12 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = get("/lines");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
+        assertResponseCode(response, HttpStatus.OK);
+        List<Long> expectedLineIds = Stream.of(createResponse1, createResponse2)
             .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
             .collect(Collectors.toList());
         List<Long> resultLineIds = response.jsonPath().getList(".", LineResponse.class).stream()
-            .map(it -> it.getId())
+            .map(LineResponse::getId)
             .collect(Collectors.toList());
         assertThat(resultLineIds).containsAll(expectedLineIds);
     }
@@ -100,7 +101,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = get("/lines/" + lineId);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertResponseCode(response, HttpStatus.OK);
         assertThat(response.jsonPath().getLong("id")).isEqualTo(lineId);
     }
 
@@ -119,7 +120,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = put(params, uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertResponseCode(response, HttpStatus.OK);
     }
 
     @DisplayName("지하철 노선을 제거한다.")
@@ -133,7 +134,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertResponseCode(response, HttpStatus.NO_CONTENT);
     }
 
     public static ExtractableResponse<Response> 지하철_노선_등록되어_있음_두_종점역_포함(Line line, Section section) {
@@ -156,7 +157,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_등록되어_있음_두_종점역_포함(line5, section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertResponseCode(response, HttpStatus.CREATED);
         assertThat(response.jsonPath().getString("name")).isEqualTo(line5.getName());
         assertThat(response.jsonPath().getString("color")).isEqualTo(line5.getColor());
         assertThat(response.jsonPath().getLong("stations[0].id")).isEqualTo(section.getUpStation().getId());
@@ -176,7 +177,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = get("/lines/" + lineId);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertResponseCode(response, HttpStatus.OK);
         List<StationResponse> stationResponses = response.as(LineResponse.class).getStations();
         assertThat(stationResponses).isNotEmpty();
         assertThat(stationResponses.get(0)).isEqualTo(aeogaeStation.toStationResponse());

--- a/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/section/SectionAcceptanceTest.java
@@ -47,7 +47,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> sectionResponse = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(sectionResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertResponseCode(sectionResponse, HttpStatus.CREATED);
         assertThat(sectionResponse.jsonPath().getLong("upStationId")).isEqualTo(section.getUpStation().getId());
         assertThat(sectionResponse.jsonPath().getLong("downStationId")).isEqualTo(section.getDownStation().getId());
         assertThat(sectionResponse.jsonPath().getLong("distance")).isEqualTo(section.getDistance());
@@ -65,8 +65,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 2, 7);
+        assertResponseCode(response, HttpStatus.CREATED);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 2, 7);
     }
 
     @DisplayName("역 사이에 새로운 역을 등록 (하행역기준)")
@@ -81,8 +81,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 2, 7);
+        assertResponseCode(response, HttpStatus.CREATED);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 2, 7);
     }
 
     @DisplayName("새로운 역을 상행 종점으로 등록")
@@ -97,8 +97,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 2, 11);
+        assertResponseCode(response, HttpStatus.CREATED);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 2, 11);
 
     }
 
@@ -114,8 +114,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 2, 10);
+        assertResponseCode(response, HttpStatus.CREATED);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 2, 10);
     }
 
     @DisplayName("예외케이스1 - 역 사이에 새로운 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록을 할 수 없음")
@@ -130,7 +130,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("예외케이스2 - 상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가할 수 없음")
@@ -145,7 +145,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(section);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("예외케이스3 - 상행역과 하행역 둘 중 하나도 포함되어있지 않으면 추가할 수 없음")
@@ -163,7 +163,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_구간_등록되어_있음(new Section(lineId, yeouidoStation, yeouinaruStation, 7));
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("구간에서 중간역 삭제")
@@ -177,8 +177,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete("/lines/" + lineResponse.getId() + "/sections?stationId=" + chungjeongnoStation.getId());
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 1, 7);
+        assertResponseCode(response, HttpStatus.NO_CONTENT);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 1, 7);
     }
 
     @DisplayName("구간에서 상행역 삭제")
@@ -192,8 +192,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete("/lines/" + lineResponse.getId() + "/sections?stationId=" + aeogaeStation.getId());
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 1, 4);
+        assertResponseCode(response, HttpStatus.NO_CONTENT);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 1, 4);
     }
 
     @DisplayName("구간에서 하행역 삭제")
@@ -207,8 +207,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete("/lines/" + lineResponse.getId() + "/sections?stationId=" + seodaemunStation.getId());
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-        checkStationSizeAndDistance(lineResponse.getId(), 1, 3);
+        assertResponseCode(response, HttpStatus.NO_CONTENT);
+        assertLineStationSizeAndDistance(lineResponse.getId(), 1, 3);
     }
 
     @DisplayName("노선에 등록되지 않은 역을 삭제 시도시 예외발생")
@@ -222,7 +222,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete("/lines/" + lineResponse.getId() + "/sections?stationId=" + gwanghwamunStation.getId());
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("구간이 1개만 남았을 경우 삭제 시도시 예외발생")
@@ -235,7 +235,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete("/lines/" + lineResponse.getId() + "/sections?stationId=" + aeogaeStation.getId());
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     public static ExtractableResponse<Response> 지하철_구간_등록되어_있음(Section section) {
@@ -261,7 +261,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
             .sum();
     }
 
-    void checkStationSizeAndDistance(Long lineId, int stationSize, int distance) {
+    void assertLineStationSizeAndDistance(Long lineId, int stationSize, int distance) {
         ExtractableResponse<Response> findLineResponse = findLine(lineId);
         assertThat(findSectionResponses(findLineResponse)).hasSize(stationSize);
         assertThat(sumDistancesSections(findLineResponse)).isEqualTo(distance);

--- a/src/test/java/nextstep/subway/section/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/section/domain/SectionsTest.java
@@ -33,7 +33,6 @@ public class SectionsTest {
     @DisplayName("생성자를 이용하여 구간을 생성시 지하철역 정렬 확인")
     @Test
     void findStationsInOrder() {
-
         // given
         List<Section> sectionList = new ArrayList<>(Arrays.asList(firstSection, secondSection, thirdSection, forthSection, fifthSection, sixthSection));
         Collections.shuffle(sectionList); //섞기

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.dto.StationResponse;
@@ -34,7 +35,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철역_등록되어_있음(gwanghwamunStation);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertResponseCode(response, HttpStatus.CREATED);
         assertThat(response.header("Location")).isNotBlank();
     }
 
@@ -48,7 +49,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철역_등록되어_있음(gwanghwamunStation);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertResponseCode(response, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("지하철역을 조회한다.")
@@ -62,12 +63,12 @@ public class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = get("/stations");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
+        assertResponseCode(response, HttpStatus.OK);
+        List<Long> expectedLineIds = Stream.of(createResponse1, createResponse2)
             .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
             .collect(Collectors.toList());
         List<Long> resultLineIds = response.jsonPath().getList(".", StationResponse.class).stream()
-            .map(it -> it.getId())
+            .map(StationResponse::getId)
             .collect(Collectors.toList());
         assertThat(resultLineIds).containsAll(expectedLineIds);
     }
@@ -83,7 +84,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = delete(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertResponseCode(response, HttpStatus.NO_CONTENT);
     }
 
     public static ExtractableResponse<Response> 지하철역_등록되어_있음(Station station) {


### PR DESCRIPTION
안녕하세요. 혜린님!
마지막 4단계네요. 
3단계에서 피드백 주신 사항들 먼저 반영하고, 구간 제거 기능을 구현했습니다. 
3단계보다는 수월했네요. 이번미션의 제일 어려운 단계는 3단계인것 같아요.
지하철역을 정렬하는 로직의 가독성이 떨어지는듯해서 재귀함수를 사용해서 한번 리팩토링 해보았습니다.

4단계를 진행하면서 구간이 삭제가 안되어서 이건 또 왜이러나 싶었습니다.
지금은 고아객체라는것이 무엇인지 알게되었지만, 
repository를 이용해서도 delete 해보고, 컬렉션에서도 delete를 해봐도 삭제가 안되어서 당황했습니다.
결국엔 둘 다 해주어야 그제서야 delete 쿼리가 날라가더군요..
이 현상에 대해 좀 더 알아보니 연관매핑된 컬렉션의 데이터를 삭제했을때 (고아객체를 만들었을떄)
고아가 된 객체를 자동으로 삭제할것인지에 대한 설정이 있다는것을 알게 되었습니다. (참 좋은 기능같습니다.)
덕분에 컬렉션에서만 삭제를 해주면 알아서 delete 쿼리를 실행해주는 JPA 최곱니다.
오늘도 한가지 얻어갑니다👍
그럼 마지막 단계도 리뷰 잘 부탁드립니다.🙏
감사합니다~!!