### PR TITLE
Step4 - 구간 삭제 코드리뷰 부탁드립니다!

### DIFF
--- a/src/main/java/nextstep/subway/domain/LineStation.java
+++ b/src/main/java/nextstep/subway/domain/LineStation.java
@@ -52,6 +52,7 @@ public class LineStation {
     public void setStation(Station station) {
         this.station = station;
         this.line.addLineStation(this);
+        this.station.addLineStation(this);
     }
 
     /**

--- a/src/main/java/nextstep/subway/domain/LineStations.java
+++ b/src/main/java/nextstep/subway/domain/LineStations.java
@@ -1,6 +1,5 @@
 package nextstep.subway.domain;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
@@ -8,7 +7,7 @@ import java.util.List;
 
 @Embeddable
 public class LineStations {
-    @OneToMany(mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "line", orphanRemoval = true)
     private List<LineStation> lineStations = new ArrayList<>();
 
     protected LineStations() {}
@@ -34,5 +33,9 @@ public class LineStations {
                 .filter(lineStation -> lineStation.station().equals(station))
                 .findFirst()
                 .isPresent();
+    }
+
+    public List<LineStation> list() {
+        return lineStations;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -24,7 +24,7 @@ public class Section extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Station downStation;
 
-    @OneToOne(mappedBy = "downSection", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "downSection")
     private Station upStation;
 
     /**
@@ -63,7 +63,9 @@ public class Section extends BaseEntity {
      */
     public void registerDownStation(Station downStation) {
         this.downStation = downStation;
-        downStation.setUpSection(this);
+        if (downStation != null) {
+            downStation.setUpSection(this);
+        }
     }
 
     public void registerLine(Line line) {
@@ -71,6 +73,10 @@ public class Section extends BaseEntity {
             this.line = line;
             line.addSections(this);
         }
+    }
+
+    public void setUpStation(Station upStation) {
+        this.upStation = upStation;
     }
 
     private boolean isRegisterAlreadyWithSameLine(Line line) {
@@ -118,5 +124,9 @@ public class Section extends BaseEntity {
 
     public Line line() {
         return line;
+    }
+
+    public Station upStation() {
+        return upStation;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,8 +1,5 @@
 package nextstep.subway.domain;
 
-import nextstep.subway.exception.NoSuchDataException;
-
-import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
@@ -10,7 +7,7 @@ import java.util.List;
 
 @Embeddable
 public class Sections {
-    @OneToMany(mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "line", orphanRemoval = true)
     private List<Section> sections = new ArrayList<>();
 
     protected Sections() {}
@@ -25,5 +22,13 @@ public class Sections {
 
     public boolean contains(Section section) {
         return sections.contains(section);
+    }
+
+    public int size() {
+        return sections.size();
+    }
+
+    public List<Section> list() {
+        return sections;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -4,6 +4,7 @@ import nextstep.subway.exception.ValueFormatException;
 import org.apache.logging.log4j.util.Strings;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,11 +22,11 @@ public class Station extends BaseEntity {
     @OneToOne(fetch = LAZY)
     private Section downSection;
 
-    @OneToOne(mappedBy = "downStation", fetch = LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "downStation", fetch = LAZY)
     private Section upSection;
 
-    @OneToMany(mappedBy = "station", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<LineStation> lineStations;
+    @OneToMany(mappedBy = "station", orphanRemoval = true)
+    private List<LineStation> lineStations = new ArrayList<>();
 
     /**
      * 생성자
@@ -63,10 +64,19 @@ public class Station extends BaseEntity {
 
     public void registerDownSection(Section downSection) {
         this.downSection = downSection;
+        if (downSection != null) {
+            downSection.setUpStation(this);
+        }
     }
 
     public void setUpSection(Section upSection) {
         this.upSection = upSection;
+    }
+
+    public void addLineStation(LineStation lineStation) {
+        if (!lineStations.contains(lineStation)) {
+            lineStations.add(lineStation);
+        }
     }
 
     /**
@@ -107,5 +117,9 @@ public class Station extends BaseEntity {
 
     public Section upSection() {
         return upSection;
+    }
+
+    public List<LineStation> lineStations() {
+        return lineStations;
     }
 }

--- a/src/main/java/nextstep/subway/line/controller/LineController.java
+++ b/src/main/java/nextstep/subway/line/controller/LineController.java
@@ -64,4 +64,10 @@ public class LineController {
         lineService.removeLine(lineId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{lineId}/sections")
+    public ResponseEntity removeStation(@PathVariable Long lineId, @RequestParam Long stationId) {
+        lineService.removeStation(lineId, stationId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/nextstep/subway/linestation/LineStationRepository.java
+++ b/src/main/java/nextstep/subway/linestation/LineStationRepository.java
@@ -1,0 +1,7 @@
+package nextstep.subway.linestation;
+
+import nextstep.subway.domain.LineStation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineStationRepository extends JpaRepository<LineStation, Long> {
+}

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -226,7 +226,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     public void 구간등록_등록확인4(int distance) throws Exception {
         //given
         지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
-
         StationResponse stationResponse = 역_생성("추가될역");
 
         //when
@@ -271,9 +270,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //given
         지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
         StationResponse stationResponse = 역_생성("추가될역");
-        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(stationResponse.getId(), 1L, 500);
-        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
-        구간_역_생성_및_노선등록됨(extractableResponse);
+        구간_역_생성_및_노선등록(stationResponse.getId(), 1L, 500);
 
         //when
         ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
@@ -288,9 +285,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //given
         지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
         StationResponse stationResponse = 역_생성("추가될역");
-        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(2L, stationResponse.getId(), 500);
-        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
-        구간_역_생성_및_노선등록됨(extractableResponse);
+        구간_역_생성_및_노선등록(2L, stationResponse.getId(), 500);
 
         //when
         ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
@@ -305,9 +300,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //given
         지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
         StationResponse stationResponse = 역_생성("추가될역");
-        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(1L, stationResponse.getId(), 500);
-        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
-        구간_역_생성_및_노선등록됨(extractableResponse);
+        구간_역_생성_및_노선등록(1L, stationResponse.getId(), 500);
 
         //when
         ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -154,7 +154,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     }
 
     @DisplayName("구간등록 - " +
-            "역 사이에 새로운 역을 등록할 경우 - " +
             "노선에 존재하는 역 하나와 노선에 존재하지 않는 역 하나, 아직 생성되지않은 구간을 생성하여 노선에 등록한다" +
             "이미 존재하는 역이 상행종점역이고 새로 등록하는 역이 상행종점역이 되는 경우")
     @Test
@@ -173,7 +172,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     }
 
     @DisplayName("구간등록 - " +
-            "역 사이에 새로운 역을 등록할 경우 - " +
             "노선에 존재하는 역 하나와 노선에 존재하지 않는 역 하나, 아직 생성되지않은 구간을 생성하여 노선에 등록한다" +
             "이미 존재하는 역이 하행종점역이고 새로 등록하는 역이 하행종점역이 되는 경우")
     @Test
@@ -237,6 +235,85 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //then
         구간_역_생성_및_노선등록안됨(extractableResponse);
+    }
+    
+    @DisplayName("구간삭제 - 노선에 포함되어 있지 않은 역은 삭제할 수 없다.")
+    @Test
+    public void 구간삭제_예외발생1() throws Exception {
+        //given
+        지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
+        StationResponse stationResponse = 역_생성("추가될역");
+
+        // when
+        ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
+
+        // then
+        구간삭제안됨(response);
+    }
+
+    @DisplayName("구간삭제 - 구간이 하나만 존재할 때 역을 삭제할 수 없다.")
+    @Test
+    public void 구간삭제_예외발생2() throws Exception {
+        //given
+        지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
+        LinesSubResponse linesSubResponse = 지하철_노선_조회();
+
+        //when
+        ExtractableResponse<Response> response = 구간삭제_요청(linesSubResponse.getStations().get(0).getId());
+
+        //then
+        구간삭제안됨(response);
+    }
+
+    @DisplayName("구간삭제 - 상행종점역을 삭제하는 경우")
+    @Test
+    public void 구간삭제_구간확인1() throws Exception {
+        //given
+        지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
+        StationResponse stationResponse = 역_생성("추가될역");
+        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(stationResponse.getId(), 1L, 500);
+        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
+        구간_역_생성_및_노선등록됨(extractableResponse);
+
+        //when
+        ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
+
+        //then
+        구간삭제됨(response);
+    }
+
+    @DisplayName("구간삭제 - 하행종점역을 삭제하는 경우")
+    @Test
+    public void 구간삭제_구간확인2() throws Exception {
+        //given
+        지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
+        StationResponse stationResponse = 역_생성("추가될역");
+        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(2L, stationResponse.getId(), 500);
+        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
+        구간_역_생성_및_노선등록됨(extractableResponse);
+
+        //when
+        ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
+
+        //then
+        구간삭제됨(response);
+    }
+
+    @DisplayName("구간삭제 - 중간역을 삭제하는 경우")
+    @Test
+    public void 구간삭제_구간확인3() throws Exception {
+        //given
+        지하철_노선_생성("테스트노선", "테스트색", "상행종점역", "하행종점역", 1000);
+        StationResponse stationResponse = 역_생성("추가될역");
+        Map<String, String> params = 구간_역_생성_및_노선등록_파라미터(1L, stationResponse.getId(), 500);
+        ExtractableResponse<Response> extractableResponse = 구간_역_생성_및_노선등록_요청(params);
+        구간_역_생성_및_노선등록됨(extractableResponse);
+
+        //when
+        ExtractableResponse<Response> response = 구간삭제_요청(stationResponse.getId());
+
+        //then
+        구간삭제됨(response);
     }
 
     private void 구간_역_생성_및_노선등록(Long upStationId, Long downStationId, int distance) {
@@ -432,5 +509,28 @@ public class LineAcceptanceTest extends AcceptanceTest {
     public static LinesSubResponse 지하철_노선_조회() {
         ExtractableResponse<Response> extractableResponse = 지하철_노선_조회_요청();
         return extractableResponse.jsonPath().getObject(".", LinesSubResponse.class);
+    }
+
+    private void 구간삭제안됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
+    }
+
+    private ExtractableResponse<Response> 구간삭제_요청(Long stationId) {
+        ExtractableResponse<Response> response =
+                given()
+                        .log().all()
+                        .queryParam("stationId", stationId)
+                        .when()
+                        .delete(location + SectionAcceptanceTest.BASE_PATH)
+                        .then()
+                        .log().all()
+                        .extract();
+        return response;
+    }
+
+    private void 구간삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(OK.value());
+        LinesSubResponse linesSubResponse = 지하철_노선_조회();
+        assertThat(linesSubResponse.getStations().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/nextstep/subway/line/LineRepositoryTest.java
+++ b/src/test/java/nextstep/subway/line/LineRepositoryTest.java
@@ -40,14 +40,9 @@ public class LineRepositoryTest {
     @Test
     public void save() {
         //given
-        Station upStation = Station.create("upStation");
-        Station downStation = Station.create("downStation");
-        stationRepository.save(upStation);
-        stationRepository.save(downStation);
-
-        Section section = Section.create(100);
-        entityManager.flush();
-        entityManager.clear();
+        Station upStation = stationRepository.save(Station.create("upStation"));
+        Station downStation = stationRepository.save(Station.create("downStation"));
+        Section section = sectionRepository.save(Section.create(100));
 
         //when
         Line savedLine = 노선저장2("새로운노선", "새로운색", upStation, downStation, section);
@@ -61,15 +56,9 @@ public class LineRepositoryTest {
     @Test
     public void update() {
         //given
-        Station upStation = Station.create("upStation");
-        Station downStation = Station.create("downStation");
-        stationRepository.save(upStation);
-        stationRepository.save(downStation);
-
-        Section section = Section.create(100);
-        entityManager.flush();
-        entityManager.clear();
-
+        Station upStation = stationRepository.save(Station.create("upStation"));
+        Station downStation = stationRepository.save(Station.create("downStation"));
+        Section section = sectionRepository.save(Section.create(100));
         Line savedLine = 노선저장2("새로운노선", "새로운색", upStation, downStation, section);
 
         //when
@@ -90,8 +79,6 @@ public class LineRepositoryTest {
         Station saveUpStation = stationRepository.save(Station.create("upStation"));
         Station saveDownStation = stationRepository.save(Station.create("downStation"));
         Section saveSection = sectionRepository.save(Section.create(100));
-        entityManager.flush();
-        entityManager.clear();
 
         Line line = 노선저장2("새로운노선", "새로운색", saveUpStation, saveDownStation, saveSection);
         Line findLine = lineRepository.findById(line.id()).orElseThrow(() -> new IllegalStateException());
@@ -113,12 +100,9 @@ public class LineRepositoryTest {
     @Test
     public void 역과구간과함께노선생성시_연관관계확인() throws Exception {
         //given
-        Station upStation = Station.create("상행종점역");
-        Station downStation = Station.create("하행종점역");
-        Section section = Section.create(100);
-        Station savedUpStation = stationRepository.save(upStation);
-        Station savedDownStation = stationRepository.save(downStation);
-        Section savedSection = sectionRepository.save(section);
+        Station savedUpStation = stationRepository.save(Station.create("상행종점역"));
+        Station savedDownStation = stationRepository.save(Station.create("하행종점역"));
+        Section savedSection = sectionRepository.save(Section.create(100));
 
         //when
         Line line = Line.createWithSectionAndStation("테스트노선", "테스트색", savedSection, savedUpStation, savedDownStation);

--- a/src/test/java/nextstep/subway/line/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/LineServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -95,17 +96,15 @@ public class LineServiceTest {
         assertThat(linesResponse.contains(LinesSubResponse.of(line2))).isTrue();
     }
 
-    @DisplayName("노선 삭제")
+    @DisplayName("노선 삭제 - 존재하지않는 노선을 삭제하는 경우 예외발생")
     @Test
-    public void 노선삭제시_노석확인() {
+    public void 노선삭제시_예외발생() {
         //given
         Long lineId = 1L;
 
         //when
-        lineService.removeLine(lineId);
-
         //then
         when(lineRepository.findById(lineId)).thenThrow(NoSuchDataException.class);
-        assertThatThrownBy(() -> lineService.readLine(lineId)).isInstanceOf(NoSuchDataException.class);
+        assertThatThrownBy(() -> lineService.removeLine(lineId)).isInstanceOf(NoSuchDataException.class);
     }
 }

--- a/src/test/java/nextstep/subway/line/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/line/LineServiceTest.java
@@ -1,14 +1,14 @@
 package nextstep.subway.line;
 
+import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
 import nextstep.subway.exception.DuplicateDataException;
 import nextstep.subway.exception.NoSuchDataException;
 import nextstep.subway.line.application.LineService;
-import nextstep.subway.domain.Line;
-import nextstep.subway.line.repository.LineRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LinesSubResponse;
-import nextstep.subway.domain.Station;
+import nextstep.subway.line.repository.LineRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/nextstep/subway/line/LineTest.java
+++ b/src/test/java/nextstep/subway/line/LineTest.java
@@ -275,4 +275,57 @@ public class LineTest {
         //then
         assertThat(line.sortedStationList()).containsExactly(upStation, newStation, downStation);
     }
+
+    @DisplayName("구간삭제 - 노선에 포함되어 있지 않은 역은 삭제할 수 없다.")
+    @Test
+    public void 구간삭제_예외발생1() throws Exception {
+        //given
+        Station upStation = new Station(1L, "상행종점역");
+        Station downStation = new Station(2L, "하행종점역");
+        Section section = new Section(1L, 100);
+        Line line = Line.createWithSectionAndStation("테스트노선", "테스트색", section, upStation, downStation);
+        Station newStation = new Station(3L, "새로운역");
+        Section newSection = new Section(2L, 50);
+        line.register(upStation, newStation, newSection);
+        Station deleteStation = new Station(4L, "삭제될역");
+
+        // when
+        // then
+        assertThatThrownBy(() -> line.validateDeletable(deleteStation)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @DisplayName("구간삭제 - 노선에 구간이 하나만 포함되어 있으면 삭제할 수 없다.")
+    @Test
+    public void 구간삭제_예외발생2() throws Exception {
+        //given
+        Station upStation = new Station(1L, "상행종점역");
+        Station downStation = new Station(2L, "하행종점역");
+        Section section = new Section(1L, 100);
+        Line line = Line.createWithSectionAndStation("테스트노선", "테스트색", section, upStation, downStation);
+
+        // when
+        // then
+        assertThatThrownBy(() -> line.validateDeletable(upStation)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @DisplayName("구간삭제 - 중간역을 삭제하는 경우 재연결확인")
+    @Test
+    public void 구간삭제_재연결확인1() throws Exception {
+        //given
+        Station upStation = new Station(1L, "상행종점역");
+        Station downStation = new Station(2L, "하행종점역");
+        Section section = new Section(1L, 100);
+        Line line = Line.createWithSectionAndStation("테스트노선", "테스트색", section, upStation, downStation);
+        Station newStation = new Station(3L, "새로운역");
+        Section newSection = new Section(2L, 50);
+        line.register(upStation, newStation, newSection);
+
+        // when
+        line.validateDeletable(newStation);
+        Section deletableSection = line.findDeletableSection(newStation);
+        line.reconnect(newStation, deletableSection);
+
+        // then
+        assertThat(line.sortedStationList()).containsExactly(upStation, downStation);
+    }
 }


### PR DESCRIPTION
안녕하세요 윤병현입니다!

3주차 주제가 ATDD였는데 ATDD자체는 장점이 많다고 생각되지만 어려운 개념은 아닌것 같다는 생각이 들었습니다.
그냥 TDD앞에 거의 완벽한 테스트 하나를 작성해두고 이게 목표가 되어 방향을 설정할 수 있는 장점을 느꼈고
단위테스트처럼 테스트 코드가 변경되는 일이 거의 없어서 장점이 많은 설계 방법인것 같습니다.

오히려 3주차때 실무경험이 없는 JPA에 대해서 많은 생각을 하게 되었습니다.
엔티티의 다중성 관계는 거의 정해져있다고 생각했는데, 관점에따라 다대다에서 일대일 관계로 변경해보는 경험도 했고,
구간 삭제의 경우 일대다, 다대일로 중간에서 매핑해주는 엔티티에 두 부모 엔티티에서 영속성전이를 할 경우, 처음 생각했던것과는 다르게 삭제쿼리가 나가지 않는 경험도 하게되었습니다.

이 번주차에서 고민했던 또 한가지는 도메인 삭제입니다.
우아한테크캠프 1주차, 2주차를 통해 도메인 모델 패턴으로 비즈니스 로직을 도메인으로 가져가는 연습을 해왔는데
도메인을 삭제하는 경우는 도메인 스스로가 해결하지 못한다는 벽에 부딪혔습니다.
도메인 생성, 수정, 조회의 로직은 도메인에서 제공할 수 있는 반면 삭제인 경우는 아직 그 방법을 찾지 못했습니다.
Java에서 객체가 스스로 null이 되는 방법이 없어서.. 이게 한계인가? 라는 생각이 들었는데
혹시 이부분에 대해 제가 놓친부분이 있으면 공유해주시면 감사하겠습니다.
그래서 4단계 미션은 서비스에서 삭제할 도메인들을 모두 조회하여 delete()하는 방식으로 구현하였습니다.

코드리뷰 부탁드립니다 감사합니다!