### PR TITLE
[Step 4] 구간 제거 기능 리뷰 요청 드립니다.

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -93,12 +93,17 @@ public class LineService {
 
 	public void removeStation(Long stationId) {
 		Set<Long> lineIds = getLineIds(stationId);
+		Station deleteStation = getStation(stationId);
+		List<Line> lineList = getLinesByIds(lineIds);
 
-		for (Long lineId : lineIds) {
-			Line line = getLine(lineId);
-			Station deleteStation = getStation(stationId);
+		for (Line line : lineList) {
 			line.remove(deleteStation);
 		}
+	}
+
+	private List<Line> getLinesByIds(Set<Long> lineIds) {
+		return lines.findByIdIn(lineIds)
+			.orElseThrow(() -> new NoSuchElementException("There is no line for the ids"));
 	}
 
 	private Set<Long> getLineIds(Long stationId) {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -1,10 +1,10 @@
 package nextstep.subway.line.application;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,9 +102,10 @@ public class LineService {
 	}
 
 	private Set<Long> getLineIds(Long stationId) {
-		Set<Long> lineIds = new HashSet<>();
-		lineIds.addAll(toLineIds(sections.findByUpStationId(stationId)));
-		lineIds.addAll(toLineIds(sections.findByDownStationId(stationId)));
+		Set<Long> lineIds = Stream
+			.concat(toLineIds(sections.findByUpStationId(stationId)).stream(),
+				toLineIds(sections.findByDownStationId(stationId)).stream())
+			.collect(Collectors.toSet());
 
 		return lineIds;
 	}

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -82,4 +82,10 @@ public class LineService {
 	private Line getLine(Long id) {
 		return lines.findById(id).orElseThrow(() -> new NoSuchElementException("There is no line for the id"));
 	}
+
+	public void removeStation(Long lineId, Long stationId) {
+		Line line = getLine(lineId);
+		Station deleteStation = getStation(stationId);
+		line.remove(deleteStation);
+	}
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -1,7 +1,9 @@
 package nextstep.subway.line.application;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -87,5 +89,27 @@ public class LineService {
 		Line line = getLine(lineId);
 		Station deleteStation = getStation(stationId);
 		line.remove(deleteStation);
+	}
+
+	public void removeStation(Long stationId) {
+		Set<Long> lineIds = getLineIds(stationId);
+
+		for (Long lineId : lineIds) {
+			Line line = getLine(lineId);
+			Station deleteStation = getStation(stationId);
+			line.remove(deleteStation);
+		}
+	}
+
+	private Set<Long> getLineIds(Long stationId) {
+		Set<Long> lineIds = new HashSet<>();
+		lineIds.addAll(toLineIds(sections.findByUpStationId(stationId)));
+		lineIds.addAll(toLineIds(sections.findByDownStationId(stationId)));
+
+		return lineIds;
+	}
+
+	private Set<Long> toLineIds(List<Section> sections) {
+		return sections.stream().map(section -> section.getLine().getId()).collect(Collectors.toSet());
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -60,4 +60,8 @@ public class Line extends BaseEntity {
 	public List<Station> getOrderedStations() {
 		return sections.getOrderedStations();
 	}
+
+	public void remove(Station targetStation) {
+		sections.remove(targetStation);
+	}
 }

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -1,6 +1,11 @@
 package nextstep.subway.line.domain;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
+	Optional<List<Line>> findByIdIn(Set<Long> lineIds);
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -66,11 +66,11 @@ public class Section extends BaseEntity {
 		this.line = line;
 	}
 
-	public boolean hasSameUpStation(Section section) {
-		return this.upStation.equals(section.getUpStation());
+	public boolean hasSameUpStation(Station station) {
+		return this.upStation.equals(station);
 	}
 
-	public boolean hasSameDownStation(Section section) {
-		return this.downStation.equals(section.getDownStation());
+	public boolean hasSameDownStation(Station station) {
+		return this.downStation.equals(station);
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -13,7 +13,7 @@ import nextstep.subway.station.domain.Station;
 
 @Entity
 public class Section extends BaseEntity {
-	private static final int MINIMUM_DISTANCE = 0;
+	public static final int MINIMUM_DISTANCE = 0;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -13,6 +13,8 @@ import nextstep.subway.station.domain.Station;
 
 @Entity
 public class Section extends BaseEntity {
+	private static final int MINIMUM_DISTANCE = 0;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -39,7 +41,14 @@ public class Section extends BaseEntity {
 		this.line = line;
 		this.upStation = upStation;
 		this.downStation = downStaion;
+		validateDistance(distance);
 		this.distance = distance;
+	}
+
+	private void validateDistance(int distance) {
+		if (distance <= MINIMUM_DISTANCE) {
+			throw new IllegalArgumentException("Distance must be positive number");
+		}
 	}
 
 	public Long getId() {

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -1,6 +1,11 @@
 package nextstep.subway.line.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+	List<Section> findByUpStationId(Long upStationId);
+
+	List<Section> findByDownStationId(Long DownStationId);
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -85,7 +85,7 @@ public class Sections {
 	}
 
 	private void modifyOldSection(Section targetSection, Section candidate, Station upStation, Station downStation) {
-		if (targetSection.getDistance() - candidate.getDistance() <= 0) {
+		if (targetSection.getDistance() - candidate.getDistance() <= Section.MINIMUM_DISTANCE) {
 			throw new IllegalArgumentException("The distance between new section must be less than target section");
 		}
 

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -90,8 +90,8 @@ public class Sections {
 
 	private void validateCandidate(Section candidate) {
 		Set<Station> stations = getDistinctStations();
-		validateAlreadyExistsTwoStations(candidate, stations);
-		validateExistsConnectedStationToOldLine(candidate, stations);
+		validateTwoStationsAlreadyExists(candidate, stations);
+		validateConnectedStationToOldLineExists(candidate, stations);
 	}
 
 	private Set<Station> getDistinctStations() {
@@ -101,13 +101,13 @@ public class Sections {
 			.collect(Collectors.toSet());
 	}
 
-	private void validateExistsConnectedStationToOldLine(Section candidate, Set<Station> stations) {
+	private void validateConnectedStationToOldLineExists(Section candidate, Set<Station> stations) {
 		if (!stations.contains(candidate.getUpStation()) && !stations.contains(candidate.getDownStation())) {
 			throw new NoSuchElementException("There is no such section");
 		}
 	}
 
-	private void validateAlreadyExistsTwoStations(Section candidate, Set<Station> stations) {
+	private void validateTwoStationsAlreadyExists(Section candidate, Set<Station> stations) {
 		if (stations.contains(candidate.getUpStation()) && stations.contains(candidate.getDownStation())) {
 			throw new IllegalArgumentException("Each two stations are already in the line");
 		}

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -166,7 +166,7 @@ public class Sections {
 
 	private void validateRemovable() {
 		if (sections.size() <= MINIMUM_SECTION_COUNT) {
-			throw new IllegalArgumentException("Section must be over at leat two count in line");
+			throw new IllegalArgumentException("Section must be over at least two count in line");
 		}
 	}
 

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -29,14 +29,14 @@ public class Sections {
 
 		validateCandidate(candidate);
 
-		Section commonUpStationSection = getCommonUpStationSection(candidate);
+		Section commonUpStationSection = getCommonUpStationSection(candidate.getUpStation());
 		if (isCommonStationExist(commonUpStationSection)) {
 			addSectionWithCommonUpStation(candidate, commonUpStationSection);
 
 			return;
 		}
 
-		Section commonDownStationSection = getCommonDownStationSection(candidate);
+		Section commonDownStationSection = getCommonDownStationSection(candidate.getDownStation());
 		if (isCommonStationExist(commonDownStationSection)) {
 			addSectionWithCommonDownStation(candidate, commonDownStationSection);
 
@@ -60,9 +60,9 @@ public class Sections {
 		addSection(candidate);
 	}
 
-	private Section getCommonDownStationSection(Section candidate) {
+	private Section getCommonDownStationSection(Station downStation) {
 		return sections.stream()
-			.filter(x -> x.hasSameDownStation(candidate))
+			.filter(section -> section.hasSameDownStation(downStation))
 			.findFirst().orElse(null);
 	}
 
@@ -76,9 +76,9 @@ public class Sections {
 		sections.add(candidate);
 	}
 
-	private Section getCommonUpStationSection(Section candidate) {
+	private Section getCommonUpStationSection(Station upStation) {
 		return sections.stream()
-			.filter(x -> x.hasSameUpStation(candidate))
+			.filter(section -> section.hasSameUpStation(upStation))
 			.findFirst().orElse(null);
 	}
 
@@ -145,5 +145,20 @@ public class Sections {
 			.filter(x -> !order.containsValue(x))
 			.findFirst()
 			.orElseThrow(() -> new NoSuchElementException("There is no start point"));
+	}
+
+	public void remove(Station targetStation) {
+		Section sectionWithSameUpStation = getCommonUpStationSection(targetStation);
+		Section sectionWithSameDownStation = getCommonDownStationSection(targetStation);
+
+		if (sectionWithSameUpStation != null && sectionWithSameDownStation != null) {
+			sections.add(new Section(sectionWithSameUpStation.getLine(),
+				sectionWithSameDownStation.getUpStation(),
+				sectionWithSameUpStation.getDownStation(),
+				sectionWithSameUpStation.getDistance() + sectionWithSameDownStation.getDistance()));
+		}
+
+		sections.remove(sectionWithSameUpStation);
+		sections.remove(sectionWithSameDownStation);
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -151,6 +151,10 @@ public class Sections {
 		Section sectionWithSameUpStation = getCommonUpStationSection(targetStation);
 		Section sectionWithSameDownStation = getCommonDownStationSection(targetStation);
 
+		if (sectionWithSameUpStation == null && sectionWithSameDownStation == null) {
+			throw new NoSuchElementException("Request station is not on the line");
+		}
+
 		if (sectionWithSameUpStation != null && sectionWithSameDownStation != null) {
 			sections.add(new Section(sectionWithSameUpStation.getLine(),
 				sectionWithSameDownStation.getUpStation(),

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -100,8 +100,8 @@ public class Sections {
 
 	private Set<Station> getDistinctStations() {
 		return sections.stream()
-			.map(x -> Arrays.asList(x.getUpStation(), x.getDownStation()))
-			.flatMap(y -> y.stream())
+			.map(section -> Arrays.asList(section.getUpStation(), section.getDownStation()))
+			.flatMap(sections -> sections.stream())
 			.collect(Collectors.toSet());
 	}
 

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -16,7 +16,9 @@ import nextstep.subway.station.domain.Station;
 
 @Embeddable
 public class Sections {
-	public static final int SIZE_ZERO = 0;
+	private static final int SIZE_ZERO = 0;
+	private static final int MINIMUM_SECTION_COUNT = 1;
+
 	@OneToMany(mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
 	List<Section> sections = new ArrayList<>();
 
@@ -148,6 +150,10 @@ public class Sections {
 	}
 
 	public void remove(Station targetStation) {
+		if (sections.size() <= MINIMUM_SECTION_COUNT) {
+			throw new IllegalArgumentException("Section must be over at leat two count in line");
+		}
+
 		Section sectionWithSameUpStation = getCommonUpStationSection(targetStation);
 		Section sectionWithSameDownStation = getCommonDownStationSection(targetStation);
 

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -150,25 +150,40 @@ public class Sections {
 	}
 
 	public void remove(Station targetStation) {
-		if (sections.size() <= MINIMUM_SECTION_COUNT) {
-			throw new IllegalArgumentException("Section must be over at leat two count in line");
-		}
+		validateRemovable();
 
 		Section sectionWithSameUpStation = getCommonUpStationSection(targetStation);
 		Section sectionWithSameDownStation = getCommonDownStationSection(targetStation);
 
-		if (sectionWithSameUpStation == null && sectionWithSameDownStation == null) {
-			throw new NoSuchElementException("Request station is not on the line");
-		}
-
-		if (sectionWithSameUpStation != null && sectionWithSameDownStation != null) {
-			sections.add(new Section(sectionWithSameUpStation.getLine(),
-				sectionWithSameDownStation.getUpStation(),
-				sectionWithSameUpStation.getDownStation(),
-				sectionWithSameUpStation.getDistance() + sectionWithSameDownStation.getDistance()));
+		validateRequestStationExists(sectionWithSameUpStation, sectionWithSameDownStation);
+		if (isUpAndDownStationExist(sectionWithSameUpStation, sectionWithSameDownStation)) {
+			connectTwoStation(sectionWithSameUpStation, sectionWithSameDownStation);
 		}
 
 		sections.remove(sectionWithSameUpStation);
 		sections.remove(sectionWithSameDownStation);
+	}
+
+	private void validateRemovable() {
+		if (sections.size() <= MINIMUM_SECTION_COUNT) {
+			throw new IllegalArgumentException("Section must be over at leat two count in line");
+		}
+	}
+
+	private void connectTwoStation(Section sectionWithSameUpStation, Section sectionWithSameDownStation) {
+		sections.add(new Section(sectionWithSameUpStation.getLine(),
+			sectionWithSameDownStation.getUpStation(),
+			sectionWithSameUpStation.getDownStation(),
+			sectionWithSameUpStation.getDistance() + sectionWithSameDownStation.getDistance()));
+	}
+
+	private boolean isUpAndDownStationExist(Section sectionWithSameUpStation, Section sectionWithSameDownStation) {
+		return sectionWithSameUpStation != null && sectionWithSameDownStation != null;
+	}
+
+	private void validateRequestStationExists(Section sectionWithSameUpStation, Section sectionWithSameDownStation) {
+		if (sectionWithSameUpStation == null && sectionWithSameDownStation == null) {
+			throw new NoSuchElementException("Request station is not on the line");
+		}
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -22,7 +22,7 @@ public class Sections {
 
 	public void add(Section candidate) {
 		if (isSectionsEmpty()) {
-			sections.add(candidate);
+			addSection(candidate);
 
 			return;
 		}
@@ -43,7 +43,7 @@ public class Sections {
 			return;
 		}
 
-		sections.add(candidate);
+		addSection(candidate);
 	}
 
 	private boolean isSectionsEmpty() {
@@ -55,8 +55,9 @@ public class Sections {
 	}
 
 	private void addSectionWithCommonDownStation(Section candidate, Section commonDownStationSection) {
-		rearrangeSections(commonDownStationSection, candidate, commonDownStationSection.getUpStation(),
+		modifyOldSection(commonDownStationSection, candidate, commonDownStationSection.getUpStation(),
 			candidate.getUpStation());
+		addSection(candidate);
 	}
 
 	private Section getCommonDownStationSection(Section candidate) {
@@ -66,8 +67,13 @@ public class Sections {
 	}
 
 	private void addSectionWithCommonUpStation(Section candidate, Section commonUpStationSection) {
-		rearrangeSections(commonUpStationSection, candidate, candidate.getDownStation(),
+		modifyOldSection(commonUpStationSection, candidate, candidate.getDownStation(),
 			commonUpStationSection.getDownStation());
+		addSection(candidate);
+	}
+
+	private void addSection(Section candidate) {
+		sections.add(candidate);
 	}
 
 	private Section getCommonUpStationSection(Section candidate) {
@@ -76,15 +82,13 @@ public class Sections {
 			.findFirst().orElse(null);
 	}
 
-	private void rearrangeSections(Section targetSection, Section candidate, Station upStation, Station downStation) {
+	private void modifyOldSection(Section targetSection, Section candidate, Station upStation, Station downStation) {
 		if (targetSection.getDistance() - candidate.getDistance() <= 0) {
 			throw new IllegalArgumentException("The distance between new section must be less than target section");
 		}
 
-		sections.add(
-			new Section(targetSection.getLine(), upStation, downStation,
-				targetSection.getDistance() - candidate.getDistance()));
-		sections.add(candidate);
+		addSection(new Section(targetSection.getLine(), upStation, downStation,
+			targetSection.getDistance() - candidate.getDistance()));
 		sections.remove(targetSection);
 	}
 

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -70,6 +70,12 @@ public class LineController {
 		return ResponseEntity.ok().build();
 	}
 
+	@DeleteMapping("/sections")
+	public ResponseEntity removeStation(@RequestParam Long stationId) {
+		lineService.removeStation(stationId);
+		return ResponseEntity.ok().build();
+	}
+
 	@ExceptionHandler(NoSuchElementException.class)
 	public ResponseEntity handleNoSuchElementException(NoSuchElementException e) {
 		return ResponseEntity.noContent().build();

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import nextstep.subway.line.application.LineService;
@@ -61,6 +62,12 @@ public class LineController {
 	@PostMapping(value = "/{lineId}/sections")
 	public ResponseEntity addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
 		return ResponseEntity.ok().body(lineService.addSectionAndReturnNewSection(lineId, sectionRequest));
+	}
+
+	@DeleteMapping("/{lineId}/sections")
+	public ResponseEntity removeStation(@PathVariable Long lineId, @RequestParam Long stationId) {
+		lineService.removeStation(lineId, stationId);
+		return ResponseEntity.ok().build();
 	}
 
 	@ExceptionHandler(NoSuchElementException.class)

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -51,6 +51,24 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		assertThat(response.header("Location")).isNotBlank();
 	}
 
+	@DisplayName("역 사이의 거리는 항상 양수다.")
+	@Test
+	void distanceBetweenStationsMustBePositiveNumber() {
+		// given
+		// 지하철_역_등록되어_있음
+		setUpStations();
+		// 지하철_노선_미등록_상태
+
+		// when
+		// 지하철_노선_생성_요청
+		ExtractableResponse<Response> response = LineAcceptanceMethod.createLine(
+			new LineRequest("신분당선", "bg-red-600", stationId1, stationId2, -1));
+
+		// then
+		// 에러_발생
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
 	@DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")
 	@Test
 	void createLineWithDuplicateName() {

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceMethod.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceMethod.java
@@ -18,4 +18,14 @@ public class SectionAcceptanceMethod {
 			.then().log().all()
 			.extract();
 	}
+
+	public static ExtractableResponse<Response> removeStation(String lineId, Long stationId) {
+		return RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId)
+			.then().log().all()
+			.extract();
+	}
 }

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceMethod.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceMethod.java
@@ -28,4 +28,14 @@ public class SectionAcceptanceMethod {
 			.then().log().all()
 			.extract();
 	}
+
+	public static ExtractableResponse<Response> removeStation(Long stationId) {
+		return RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/sections?stationId=" + stationId)
+			.then().log().all()
+			.extract();
+	}
 }

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -175,4 +175,100 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		// 에러_발생
 		assertThat(addResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
+
+	@DisplayName("두 역 사이의 역을 삭제한다.")
+	@Test
+	void deleteStationBetweenStations() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+		// 지하철_역(사이(between)_역)_등록되어 있음
+
+		// when
+		// 두_역_사이의_역을_삭제_요청
+
+		// then
+		// 지하철_역_삭제_됨
+		// 지하철_삭제_조회
+	}
+
+	@DisplayName("상행 종점 역을 삭제한다.")
+	@Test
+	void deleteUpStation() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+		// 지하철_역(사이(between)_역)_등록되어 있음
+
+		// when
+		// 상행_종점_역을_삭제_요청
+
+		// then
+		// 지하철_역_삭제_됨
+		// 지하철_삭제_조회
+	}
+
+	@DisplayName("하행 종점 역을 삭제한다.")
+	@Test
+	void deleteDownStation() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+		// 지하철_역(사이(between)_역)_등록되어 있음
+
+		// when
+		// 하행_종점_역을_삭제_요청
+
+		// then
+		// 지하철_역_삭제_됨
+		// 지하철_삭제_조회
+	}
+
+	@DisplayName("노선에 없는 역을 삭제한다.")
+	@Test
+	void deleteNotExistStation() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+		// 지하철_역(사이(between)_역)_등록되어 있음
+		// 다른_역_등록
+
+		// when
+		// 다른_역을_삭제_요청
+
+		// then
+		// 에러 발생
+	}
+
+	@DisplayName("구간이 하나일 때 상행 종점 혹은 하행 종점을 삭제한다.")
+	@Test
+	void deleteTerminalStationAndSectionIsOnlyOne() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+
+		// when
+		// 상행_종점_삭제_요청
+		// 하행_종점_삭제_요청
+
+		// then
+		// 에러_발생
+	}
+
+	@DisplayName("다른 노선에 역이 존재할 때 삭제한다.(환승역)")
+	@Test
+	void deleteTransferStation() {
+		// given
+		// 지하철_역_등록되어_있음
+		// 지하철_노선_등록되어_있음
+		// 지하철_역(사이(between)_역)_등록되어 있음
+		// 등록한_지하철_역이_포함된_노선_등록
+
+		// when
+		// 환승역_삭제_요청
+
+		// then
+		// 지하철_역_삭제_됨
+		// 지하철_삭제_조회
+	}
 }

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
@@ -183,13 +185,28 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		// 지하철_역_등록되어_있음
 		// 지하철_노선_등록되어_있음
 		// 지하철_역(사이(between)_역)_등록되어 있음
+		Long stationId3 = StationAcceptanceMethod.getStationID(StationAcceptanceMethod.createStations(
+			new StationRequest("강남역")));
+		ExtractableResponse<Response> addResponse = SectionAcceptanceMethod.addSection(lineId,
+			new SectionRequest(stationId1, stationId3, 4));
 
 		// when
 		// 두_역_사이의_역을_삭제_요청
+		ExtractableResponse<Response> deleteResponse = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId3)
+			.then().log().all()
+			.extract();
 
 		// then
 		// 지하철_역_삭제_됨
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 		// 지하철_삭제_조회
+		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
+		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
+			.stream().map(it -> it.getName()).collect(Collectors.toList())).containsExactly("교대역", "역삼역");
 	}
 
 	@DisplayName("상행 종점 역을 삭제한다.")
@@ -199,13 +216,28 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		// 지하철_역_등록되어_있음
 		// 지하철_노선_등록되어_있음
 		// 지하철_역(사이(between)_역)_등록되어 있음
+		Long stationId3 = StationAcceptanceMethod.getStationID(StationAcceptanceMethod.createStations(
+			new StationRequest("강남역")));
+		ExtractableResponse<Response> addResponse = SectionAcceptanceMethod.addSection(lineId,
+			new SectionRequest(stationId1, stationId3, 4));
 
 		// when
 		// 상행_종점_역을_삭제_요청
+		ExtractableResponse<Response> deleteResponse = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId1)
+			.then().log().all()
+			.extract();
 
 		// then
 		// 지하철_역_삭제_됨
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 		// 지하철_삭제_조회
+		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
+		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
+			.stream().map(it -> it.getName()).collect(Collectors.toList())).containsExactly("강남역", "역삼역");
 	}
 
 	@DisplayName("하행 종점 역을 삭제한다.")
@@ -215,13 +247,28 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		// 지하철_역_등록되어_있음
 		// 지하철_노선_등록되어_있음
 		// 지하철_역(사이(between)_역)_등록되어 있음
+		Long stationId3 = StationAcceptanceMethod.getStationID(StationAcceptanceMethod.createStations(
+			new StationRequest("강남역")));
+		ExtractableResponse<Response> addResponse = SectionAcceptanceMethod.addSection(lineId,
+			new SectionRequest(stationId1, stationId3, 4));
 
 		// when
 		// 하행_종점_역을_삭제_요청
+		ExtractableResponse<Response> deleteResponse = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId2)
+			.then().log().all()
+			.extract();
 
 		// then
 		// 지하철_역_삭제_됨
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 		// 지하철_삭제_조회
+		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
+		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
+			.stream().map(it -> it.getName()).collect(Collectors.toList())).containsExactly("교대역", "강남역");
 	}
 
 	@DisplayName("노선에 없는 역을 삭제한다.")
@@ -231,13 +278,27 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		// 지하철_역_등록되어_있음
 		// 지하철_노선_등록되어_있음
 		// 지하철_역(사이(between)_역)_등록되어 있음
+		Long stationId3 = StationAcceptanceMethod.getStationID(StationAcceptanceMethod.createStations(
+			new StationRequest("강남역")));
+		ExtractableResponse<Response> addResponse = SectionAcceptanceMethod.addSection(lineId,
+			new SectionRequest(stationId1, stationId3, 4));
 		// 다른_역_등록
+		Long stationId4 = StationAcceptanceMethod.getStationID(StationAcceptanceMethod.createStations(
+			new StationRequest("신촌역")));
 
 		// when
 		// 다른_역을_삭제_요청
+		ExtractableResponse<Response> deleteResponse = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId4)
+			.then().log().all()
+			.extract();
 
 		// then
 		// 에러 발생
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
 
 	@DisplayName("구간이 하나일 때 상행 종점 혹은 하행 종점을 삭제한다.")
@@ -249,26 +310,26 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 상행_종점_삭제_요청
+		ExtractableResponse<Response> deleteResponse1 = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId1)
+			.then().log().all()
+			.extract();
+
 		// 하행_종점_삭제_요청
+		ExtractableResponse<Response> deleteResponse2 = RestAssured
+			.given().log().all()
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.when()
+			.delete("/lines/" + lineId + "/sections?stationId=" + stationId2)
+			.then().log().all()
+			.extract();
 
 		// then
 		// 에러_발생
-	}
-
-	@DisplayName("다른 노선에 역이 존재할 때 삭제한다.(환승역)")
-	@Test
-	void deleteTransferStation() {
-		// given
-		// 지하철_역_등록되어_있음
-		// 지하철_노선_등록되어_있음
-		// 지하철_역(사이(between)_역)_등록되어 있음
-		// 등록한_지하철_역이_포함된_노선_등록
-
-		// when
-		// 환승역_삭제_요청
-
-		// then
-		// 지하철_역_삭제_됨
-		// 지하철_삭제_조회
+		assertThat(deleteResponse1.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+		assertThat(deleteResponse2.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 	}
 }

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -298,7 +298,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		// 에러 발생
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
 
 	@DisplayName("구간이 하나일 때 상행 종점 혹은 하행 종점을 삭제한다.")

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -202,7 +202,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -233,7 +233,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -264,7 +264,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -298,7 +298,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		// 에러 발생
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 	}
 
 	@DisplayName("구간이 하나일 때 상행 종점 혹은 하행 종점을 삭제한다.")

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -8,9 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
@@ -192,17 +190,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 두_역_사이의_역을_삭제_요청
-		ExtractableResponse<Response> deleteResponse = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId3)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse = SectionAcceptanceMethod.removeStation(lineId, stationId3);
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(removeResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -223,17 +215,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 상행_종점_역을_삭제_요청
-		ExtractableResponse<Response> deleteResponse = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId1)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse = SectionAcceptanceMethod.removeStation(lineId, stationId1);
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(removeResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -254,17 +240,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 하행_종점_역을_삭제_요청
-		ExtractableResponse<Response> deleteResponse = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId2)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse = SectionAcceptanceMethod.removeStation(lineId, stationId2);
 
 		// then
 		// 지하철_역_삭제_됨
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(removeResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 		// 지하철_삭제_조회
 		ExtractableResponse<Response> findResponse = LineAcceptanceMethod.findLine(lineId);
 		assertThat(findResponse.jsonPath().getObject(".", LineResponse.class).getStations()
@@ -288,17 +268,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 다른_역을_삭제_요청
-		ExtractableResponse<Response> deleteResponse = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId4)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse = SectionAcceptanceMethod.removeStation(lineId, stationId4);
 
 		// then
 		// 에러 발생
-		assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(removeResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
 
 	@DisplayName("구간이 하나일 때 상행 종점 혹은 하행 종점을 삭제한다.")
@@ -310,26 +284,14 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		// 상행_종점_삭제_요청
-		ExtractableResponse<Response> deleteResponse1 = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId1)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse1 = SectionAcceptanceMethod.removeStation(lineId, stationId1);
 
 		// 하행_종점_삭제_요청
-		ExtractableResponse<Response> deleteResponse2 = RestAssured
-			.given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.when()
-			.delete("/lines/" + lineId + "/sections?stationId=" + stationId2)
-			.then().log().all()
-			.extract();
+		ExtractableResponse<Response> removeResponse2 = SectionAcceptanceMethod.removeStation(lineId, stationId2);
 
 		// then
 		// 에러_발생
-		assertThat(deleteResponse1.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-		assertThat(deleteResponse2.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+		assertThat(removeResponse1.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+		assertThat(removeResponse2.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 	}
 }


### PR DESCRIPTION
### Description
스텝 4 구간 제거 기능 입니다. 제거할 역을 전달하면 해당 역을 구간에서 삭제하고, 삭제된 역을 제외하고 남은 역을 서로 연결해줍니다.

인수테스트 주도 개발(ATDD) 마지막 스텝이네요. 해당 미션을 처음 시작할 땐 ATDD란 개발방법에 익숙하지도 않고 로직 구현도 무척 어려웠지만, 고민하면서 한단계 한단계 스텝을 밟아나가니 3단계 스텝부턴 무척 재밌었습니다.
이번 스텝도 꽤 재밌게 구현했습니다. 인수테스트의 테스트 대상이 노선이 한 개일 경우를 가정한 상태로 만든 것 같아, 마지막에는 환승역 삭제에 대한 로직도 구현해보았습니다. : )
참고로, 역의 순서나 이름은 서울 지하철과 비슷하지만 현실과는 전혀 맞지 않습니다 ㅎㅎㅎ

ATDD를 진행하면서 궁금한 점이 있습니다. 해당 미션을 진행하며 작성한 테스트 코드는 인수테스트에 해당하는 테스트 코드를 주로 작성하였고, 반대로 도메인에 대한 테스트 코드(메소드에 대한 테스트 코드 등)는 별로 작성하지 않은 듯 합니다. 인수테스트 주도 개발에서는 이러한 개발 방법이 맞는 것인지, 아니면 보통 기본적인 TDD를 할 때 처럼 각 도메인에 대한 테스트 코드도 작성해주는 것이 맞는지 궁금합니다 : )

피드백 받으면서 많은 공부가 되고 있습니다. 이번에도 많은 피드백 부탁드립니다.

확인 부탁드립니다.
감사합니다 : )