### PR TITLE
2단계 - 인수 테스트 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,105 @@ public class LineController {
 ```
 **3.인수 테스트 리팩터링**
 인수 테스트의 각 스텝들을 메서드로 분리하여 재사용하세요.
+ex) 인수 테스트 요청 로직 중복 제거 등# 우아한 테크 캠프 Pro - 미션 3
+
+## 미션명 : ATDD(인수 테스트 주도 개발)
+
+### # 1단계 : 지하철 노선도 관리
+
+#### 요구 사항
+
+- 지하철 노선 관리 기능을 구현하기
+    - 기능 목록: 생성 / 목록 조회 / 조회 / 수정 / 삭제
+    - 기능 구현 전 인수 테스트 작성
+    - 기능 구현 후 인수 테스트 리팩터링
+
+#### 단계별 요구사항
+
+**1.지하철 노선 관련 기능의 인수 테스트를 작성하기**
+- LineAcceptanceTest 를 모두 완성시키세요.
+```java
+@DisplayName("지하철 노선 관련 기능")
+public class LineAcceptanceTest extends AcceptanceTest {
+    @DisplayName("지하철 노선을 생성한다.")
+    @Test
+    void createLine() {
+        // when
+        // 지하철_노선_생성_요청
+
+        // then
+        // 지하철_노선_생성됨
+    }
+
+    ...
+}
+```
+
+
+**2.지하철 노선 관련 기능 구현하기**
+- 인수 테스트가 모두 성공할 수 있도록 LineController를 통해 요청을 받고 처리하는 기능을 구현하세요.
+```java
+@RestController
+@RequestMapping("/lines")
+public class LineController {
+
+    ...
+
+	@PostMapping
+	public ResponseEntity createLine(@RequestBody LineRequest lineRequest) {
+		// TODO
+	}
+
+	@GetMapping
+	public ResponseEntity<List<LineResponse>> findAllLines() {
+		// TODO
+	}
+    
+    ...
+}
+```
+**3.인수 테스트 리팩터링**
+인수 테스트의 각 스텝들을 메서드로 분리하여 재사용하세요.
 ex) 인수 테스트 요청 로직 중복 제거 등
+
+
+### # 2단계 : 인수 테스트 리팩터링
+
+#### 요구 사항
+
+1.노선 생성 시 종점역(상행, 하행) 정보를 요청 파라미터에 함께 추가하기
+
+- 두 종점역은 **구간**의 형태로 관리되어야 함
+
+```java
+public class LineRequest {
+    private String name;
+    private String color;
+    private Long upStationId;       // 추가
+    private Long downStationId;     // 추가
+    private int distance;           // 추가
+    ...
+}
+```
+
+
+
+2.노선 객체에서 구간 정보를 관리하기
+
+- 노선 생성시 전달되는 두 종점역은 노선의 상태로 관리되는 것이 아니라 구간으로 관리되어야 함
+
+```java
+public class Line {
+    ...
+    private List<Section> sections;
+    ...
+}
+```
+
+
+
+3.노선의 역 목록을 조회하는 기능 구현하기
+
+- 노선 조회 시 역 목록을 함께 응답할 수 있도록 변경
+- 노선에 등록된 구간을 순서대로 정렬하여(상행역 부터 하행역 순) 상행 종점부터 하행 종점까지 목록을 응답하기
+- 필요시 노선과 구간(혹은 역)의 관계를 새로 맺기

--- a/src/main/java/nextstep/subway/common/SubwayExceptionHandler.java
+++ b/src/main/java/nextstep/subway/common/SubwayExceptionHandler.java
@@ -1,0 +1,21 @@
+package nextstep.subway.common;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SubwayExceptionHandler {
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return ResponseEntity.badRequest().build();
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity handleIllegalArgsException(IllegalArgumentException e) {
+		return ResponseEntity.badRequest().build();
+	}
+
+}

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -6,8 +6,12 @@ import java.util.stream.Collectors;
 
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.line.domain.SectionRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,14 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class LineService {
 	private final LineRepository lineRepository;
+	private final SectionRepository sectionRepository;
 
-	public LineService(LineRepository lineRepository) {
+	public LineService(LineRepository lineRepository, SectionRepository sectionRepository) {
 		this.lineRepository = lineRepository;
+		this.sectionRepository = sectionRepository;
 	}
 
 	@Transactional
 	public LineResponse saveLine(LineRequest request) {
 		Line persistLine = lineRepository.save(request.toLine());
+
+		Section endToend = new Section(persistLine, new Station(request.getUpStationId()),
+			new Station(request.getDownStationId()),
+			request.getDistance());
+
+		sectionRepository.save(endToend);
 		return LineResponse.of(persistLine);
 	}
 
@@ -36,6 +48,7 @@ public class LineService {
 
 	@Transactional
 	public void deleteLineById(Long id) {
+		sectionRepository.deleteAllByLineId(id);
 		lineRepository.deleteById(id);
 	}
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -8,6 +8,7 @@ import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.domain.SectionRepository;
+import nextstep.subway.line.domain.Sections;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.application.StationService;
@@ -52,6 +53,13 @@ public class LineService {
 			.collect(Collectors.toList());
 	}
 
+	public List<LineResponse> findAllLineWithSections(){
+		List<Line> lines = lineRepository.findAllLinesWithSectionsAndStations();
+		return lines.stream()
+			.map(LineResponse::of)
+			.collect(Collectors.toList());
+	}
+
 	@Transactional
 	public void deleteLineById(Long id) {
 		sectionRepository.deleteAllByLineId(id);
@@ -59,7 +67,20 @@ public class LineService {
 	}
 
 	public LineResponse findLineById(Long id) {
-		return LineResponse.of(getLine(id));
+		Line line = getLine(id);
+		return LineResponse.of(line);
+	}
+
+	public LineResponse findLineWithSectionsById(Long id){
+		Line line = lineRepository.findLineWithSectionsAndStationsById(id);
+		validateExistLine(line);
+		return LineResponse.of(line);
+	}
+
+	private void validateExistLine(Line line) {
+		if(line == null){
+			throw new IllegalArgumentException("없는 노선입니다.");
+		}
 	}
 
 	@Transactional

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -1,7 +1,6 @@
 package nextstep.subway.line.application;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import nextstep.subway.line.domain.Line;
@@ -13,27 +12,28 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class LineService {
-	private LineRepository lineRepository;
+	private final LineRepository lineRepository;
 
 	public LineService(LineRepository lineRepository) {
 		this.lineRepository = lineRepository;
 	}
 
+	@Transactional
 	public LineResponse saveLine(LineRequest request) {
 		Line persistLine = lineRepository.save(request.toLine());
 		return LineResponse.of(persistLine);
 	}
 
-	@Transactional(readOnly = true)
 	public List<LineResponse> findAllLines() {
 		List<Line> lines = lineRepository.findAll();
 		return lines.stream()
-			.map(line -> LineResponse.of(line))
+			.map(LineResponse::of)
 			.collect(Collectors.toList());
 	}
 
+	@Transactional
 	public void deleteLineById(Long id) {
 		lineRepository.deleteById(id);
 	}
@@ -42,6 +42,7 @@ public class LineService {
 		return LineResponse.of(getLine(id));
 	}
 
+	@Transactional
 	public void updateLine(Long id, LineRequest lineRequest) {
 		Line findLine = getLine(id);
 		findLine.update(lineRequest.toLine());

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -1,6 +1,7 @@
 package nextstep.subway.line.application;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import nextstep.subway.line.domain.Line;
@@ -49,6 +50,7 @@ public class LineService {
 	}
 
 	private Line getLine(Long id) {
-		return lineRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("없는 노선입니다."));
+		Optional<Line> findLine = lineRepository.findById(id);
+		return findLine.orElseThrow(() -> new IllegalArgumentException("없는 노선입니다."));
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -1,14 +1,10 @@
 package nextstep.subway.line.domain;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import nextstep.subway.common.BaseEntity;
 
 import javax.persistence.*;
-
-import org.hibernate.engine.internal.Cascade;
 
 @Entity
 public class Line extends BaseEntity {
@@ -19,8 +15,8 @@ public class Line extends BaseEntity {
 	private String name;
 	private String color;
 
-	@OneToMany(mappedBy = "line")
-	private List<Section> sections = new ArrayList<>();
+	@Embedded
+	private Sections sections = new Sections();
 
 	public Line() {
 	}
@@ -28,7 +24,6 @@ public class Line extends BaseEntity {
 	public Line(String name, String color) {
 		this.name = name;
 		this.color = color;
-		// this.sections.add(section);
 	}
 
 	public void addSection(Section section) {
@@ -52,7 +47,7 @@ public class Line extends BaseEntity {
 		return color;
 	}
 
-	public List<Section> getSections() {
+	public Sections getSections() {
 		return sections;
 	}
 
@@ -83,5 +78,4 @@ public class Line extends BaseEntity {
 			", color='" + color + '\'' +
 			'}';
 	}
-
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -1,8 +1,13 @@
 package nextstep.subway.line.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import nextstep.subway.common.BaseEntity;
 
 import javax.persistence.*;
+
+import org.hibernate.engine.internal.Cascade;
 
 @Entity
 public class Line extends BaseEntity {
@@ -13,15 +18,23 @@ public class Line extends BaseEntity {
     private String name;
     private String color;
 
+    @OneToMany(mappedBy = "line")
+    private List<Section> sections=new ArrayList<>();
+
     public Line() {
     }
 
-    public Line(String name, String color) {
+	public Line(String name, String color) {
         this.name = name;
         this.color = color;
+        // this.sections.add(section);
+	}
+
+	public void addSection(Section section){
+        sections.add(section);
     }
 
-    public void update(Line line) {
+	public void update(Line line) {
         this.name = line.getName();
         this.color = line.getColor();
     }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -2,6 +2,7 @@ package nextstep.subway.line.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import nextstep.subway.common.BaseEntity;
 
@@ -11,43 +12,76 @@ import org.hibernate.engine.internal.Cascade;
 
 @Entity
 public class Line extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    @Column(unique = true)
-    private String name;
-    private String color;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(unique = true)
+	private String name;
+	private String color;
 
-    @OneToMany(mappedBy = "line")
-    private List<Section> sections=new ArrayList<>();
+	@OneToMany(mappedBy = "line")
+	private List<Section> sections = new ArrayList<>();
 
-    public Line() {
-    }
-
-	public Line(String name, String color) {
-        this.name = name;
-        this.color = color;
-        // this.sections.add(section);
+	public Line() {
 	}
 
-	public void addSection(Section section){
-        sections.add(section);
-    }
+	public Line(String name, String color) {
+		this.name = name;
+		this.color = color;
+		// this.sections.add(section);
+	}
+
+	public void addSection(Section section) {
+		sections.add(section);
+	}
 
 	public void update(Line line) {
-        this.name = line.getName();
-        this.color = line.getColor();
-    }
+		this.name = line.getName();
+		this.color = line.getColor();
+	}
 
-    public Long getId() {
-        return id;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public String getColor() {
-        return color;
-    }
+	public String getColor() {
+		return color;
+	}
+
+	public List<Section> getSections() {
+		return sections;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof Line)) {
+			return false;
+		}
+
+		Line line = (Line)o;
+		return Objects.equals(getId(), line.getId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId());
+	}
+
+	@Override
+	public String toString() {
+		return "Line{" +
+			"id=" + id +
+			", name='" + name + '\'' +
+			", color='" + color + '\'' +
+			'}';
+	}
+
 }

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -1,6 +1,24 @@
 package nextstep.subway.line.domain;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
+
+	@Query("select l from Line l " +
+		"left join fetch l.sections.sections s " +
+		"left join fetch s.upStation " +
+		"left join fetch s.downStation " +
+		"where l.id=:id")
+	Line findLineWithSectionsAndStationsById(@Param("id") Long id);
+
+	@Query("select l from Line l " +
+		"left join fetch l.sections.sections s " +
+		"left join fetch s.upStation " +
+		"left join fetch s.downStation")
+	List<Line> findAllLinesWithSectionsAndStations();
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -1,0 +1,44 @@
+package nextstep.subway.line.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import nextstep.subway.station.domain.Station;
+
+@Entity
+public class Section {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="line_id", foreignKey = @ForeignKey(name = "fk_section_line"))
+	private Line line;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="up_station_id", foreignKey = @ForeignKey(name = "fk_section_up_station"))
+	private Station upStation;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="down_station_id", foreignKey = @ForeignKey(name = "fk_section_down_station"))
+	private Station downStation;
+
+	private int distance;
+
+	public Section() {
+	}
+
+	public Section(Line line, Station upStation, Station downStation, int distance) {
+		this.line=line;
+		this.upStation=upStation;
+		this.downStation=downStation;
+		this.distance=distance;
+	}
+}

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -1,5 +1,7 @@
 package nextstep.subway.line.domain;
 
+import java.util.Objects;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
@@ -19,15 +21,15 @@ public class Section {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name="line_id", foreignKey = @ForeignKey(name = "fk_section_line"))
+	@JoinColumn(name = "line_id", foreignKey = @ForeignKey(name = "fk_section_line"))
 	private Line line;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name="up_station_id", foreignKey = @ForeignKey(name = "fk_section_up_station"))
+	@JoinColumn(name = "up_station_id", foreignKey = @ForeignKey(name = "fk_section_up_station"))
 	private Station upStation;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name="down_station_id", foreignKey = @ForeignKey(name = "fk_section_down_station"))
+	@JoinColumn(name = "down_station_id", foreignKey = @ForeignKey(name = "fk_section_down_station"))
 	private Station downStation;
 
 	private int distance;
@@ -36,9 +38,58 @@ public class Section {
 	}
 
 	public Section(Line line, Station upStation, Station downStation, int distance) {
-		this.line=line;
-		this.upStation=upStation;
-		this.downStation=downStation;
-		this.distance=distance;
+		this.line = line;
+		this.upStation = upStation;
+		this.downStation = downStation;
+		this.distance = distance;
+
+		line.addSection(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof Line)) {
+			return false;
+		}
+
+		Section section = (Section)o;
+		return Objects.equals(id, section.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	@Override
+	public String toString() {
+		return "Section{" +
+			"id=" + id +
+			", distance=" + distance +
+			'}';
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Line getLine() {
+		return line;
+	}
+
+	public Station getUpStation() {
+		return upStation;
+	}
+
+	public Station getDownStation() {
+		return downStation;
+	}
+
+	public int getDistance() {
+		return distance;
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -46,6 +46,26 @@ public class Section {
 		line.addSection(this);
 	}
 
+	public Long getId() {
+		return id;
+	}
+
+	public Line getLine() {
+		return line;
+	}
+
+	public Station getUpStation() {
+		return upStation;
+	}
+
+	public Station getDownStation() {
+		return downStation;
+	}
+
+	public int getDistance() {
+		return distance;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -73,23 +93,4 @@ public class Section {
 			'}';
 	}
 
-	public Long getId() {
-		return id;
-	}
-
-	public Line getLine() {
-		return line;
-	}
-
-	public Station getUpStation() {
-		return upStation;
-	}
-
-	public Station getDownStation() {
-		return downStation;
-	}
-
-	public int getDistance() {
-		return distance;
-	}
 }

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -1,0 +1,8 @@
+package nextstep.subway.line.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+
+	public void deleteAllByLineId(Long lineId);
+}

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
-	public void deleteAllByLineId(Long lineId);
+	void deleteAllByLineId(Long lineId);
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,0 +1,68 @@
+package nextstep.subway.line.domain;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+import nextstep.subway.station.domain.Station;
+
+@Embeddable
+public class Sections {
+
+	@OneToMany(mappedBy = "line")
+	private List<Section> sections = new ArrayList<>();
+
+	public Sections() {
+	}
+
+	public Sections(List<Section> sections) {
+		this.sections = sections;
+	}
+
+	public void add(Section section) {
+		sections.add(section);
+	}
+
+	public List<Section> getSections() {
+		return sections;
+	}
+
+	public List<Station> getStations() {
+		Station startStation = findStartStation();
+		return getOrderedStations(startStation);
+	}
+
+	private List<Station> getOrderedStations(Station startStation) {
+		Map<Station, Station> upDownStations = getUpDownRoute();
+		List<Station> stations = new ArrayList<>();
+		Station nextStation = startStation;
+		while (upDownStations.containsKey(nextStation)) {
+			stations.add(nextStation);
+			stations.add(upDownStations.get(nextStation));
+			nextStation = upDownStations.get(nextStation);
+		}
+		return stations;
+	}
+
+	private Map<Station, Station> getUpDownRoute() {
+		return sections.stream()
+			.collect(Collectors.toMap(entry -> entry.getUpStation(), entry -> entry.getDownStation(),
+				(o1, o2) -> o1, HashMap::new));
+	}
+
+	private Station findStartStation() {
+		Set<Station> downStations = sections.stream().map(it -> it.getDownStation()).collect(Collectors.toSet());
+		Optional<Station> notDownStation = sections.stream()
+			.map(it -> it.getUpStation())
+			.filter(it -> !downStations.contains(it))
+			.findFirst();
+		return notDownStation.orElseThrow(() -> new IllegalStateException("구간 정보가 올바르지 않습니다."));
+	}
+}

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -5,13 +5,19 @@ import nextstep.subway.line.domain.Line;
 public class LineRequest {
     private String name;
     private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
 
     public LineRequest() {
     }
 
-    public LineRequest(String name, String color) {
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
         this.name = name;
         this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
     }
 
     public String getName() {

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -28,6 +28,18 @@ public class LineRequest {
         return color;
     }
 
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
     public Line toLine() {
         return new Line(name, color);
     }

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -2,6 +2,7 @@ package nextstep.subway.line.dto;
 
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.Section;
+import nextstep.subway.line.domain.Sections;
 import nextstep.subway.station.domain.Station;
 
 import java.time.LocalDateTime;
@@ -12,29 +13,29 @@ public class LineResponse {
     private Long id;
     private String name;
     private String color;
-    private List<Station> stations;
+    private List<Station> stations = new ArrayList<>();
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
-
 
     public LineResponse() {
     }
 
-    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate, List<Section> sections) {
+    public LineResponse(Long id, String name, String color,Sections sections, LocalDateTime createdDate, LocalDateTime modifiedDate ) {
+       this(id,name,color,sections.getStations(),createdDate,modifiedDate);
+    }
+
+    public LineResponse(Long id, String name, String color, List<Station> stations, LocalDateTime createdDate,
+        LocalDateTime modifiedDate) {
         this.id = id;
         this.name = name;
         this.color = color;
+        this.stations = stations;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
-        this.stations= new ArrayList<>();
-        for(Section section : sections){
-            this.stations.add(section.getUpStation());
-            this.stations.add(section.getDownStation());
-        }
     }
 
     public static LineResponse of(Line line) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getCreatedDate(), line.getModifiedDate(),line.getSections());
+        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getSections(), line.getCreatedDate(), line.getModifiedDate());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -1,29 +1,40 @@
 package nextstep.subway.line.dto;
 
 import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.station.domain.Station;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LineResponse {
     private Long id;
     private String name;
     private String color;
+    private List<Station> stations;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
+
 
     public LineResponse() {
     }
 
-    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate, List<Section> sections) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+        this.stations= new ArrayList<>();
+        for(Section section : sections){
+            this.stations.add(section.getUpStation());
+            this.stations.add(section.getDownStation());
+        }
     }
 
     public static LineResponse of(Line line) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getCreatedDate(), line.getModifiedDate());
+        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getCreatedDate(), line.getModifiedDate(),line.getSections());
     }
 
     public Long getId() {
@@ -44,5 +55,9 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public List<Station> getStations() {
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -3,13 +3,10 @@ package nextstep.subway.line.ui;
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
-import nextstep.subway.station.dto.StationResponse;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -57,14 +57,4 @@ public class LineController {
 		lineService.deleteLineById(id);
 		return ResponseEntity.noContent().build();
 	}
-
-	@ExceptionHandler(DataIntegrityViolationException.class)
-	public ResponseEntity handleDataIntegrityViolationException(DataIntegrityViolationException e) {
-		return ResponseEntity.badRequest().build();
-	}
-
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity handleIllegalArgsException(IllegalArgumentException e) {
-		return ResponseEntity.badRequest().build();
-	}
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -31,7 +31,7 @@ public class LineController {
 	}
 
 	@PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity createLine(@RequestBody LineRequest lineRequest) {
+	public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
 		LineResponse line = lineService.saveLine(lineRequest);
 		return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
 	}
@@ -42,7 +42,7 @@ public class LineController {
 	}
 
 	@GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity showLine(@PathVariable Long id) {
+	public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
 		return ResponseEntity.ok().body(lineService.findLineById(id));
 	}
 

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -4,6 +4,7 @@ import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,12 +36,14 @@ public class LineController {
 
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<LineResponse>> showLines() {
-		return ResponseEntity.ok().body(lineService.findAllLines());
+		List<LineResponse> lines = lineService.findAllLineWithSections();
+		return ResponseEntity.ok().body(lines);
 	}
 
 	@GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
-		return ResponseEntity.ok().body(lineService.findLineById(id));
+		LineResponse lineResponse = lineService.findLineWithSectionsById(id);
+		return new ResponseEntity<>(lineResponse, HttpStatus.OK);
 	}
 
 	@PutMapping("/{id}")

--- a/src/main/java/nextstep/subway/station/application/StationService.java
+++ b/src/main/java/nextstep/subway/station/application/StationService.java
@@ -1,5 +1,7 @@
 package nextstep.subway.station.application;
 
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 import nextstep.subway.station.dto.StationRequest;
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,5 +39,14 @@ public class StationService {
     @Transactional
     public void deleteStationById(Long id) {
         stationRepository.deleteById(id);
+    }
+
+	public StationResponse findStationById(Long id) {
+        return StationResponse.of(getStationEntity(id));
+	}
+
+    public Station getStationEntity(Long id) {
+        Optional<Station> findStation = stationRepository.findById(id);
+        return findStation.orElseThrow(() -> new IllegalArgumentException("없는 지하철 역입니다."));
     }
 }

--- a/src/main/java/nextstep/subway/station/application/StationService.java
+++ b/src/main/java/nextstep/subway/station/application/StationService.java
@@ -11,28 +11,29 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;
     }
 
+    @Transactional
     public StationResponse saveStation(StationRequest stationRequest) {
         Station persistStation = stationRepository.save(stationRequest.toStation());
         return StationResponse.of(persistStation);
     }
 
-    @Transactional(readOnly = true)
     public List<StationResponse> findAllStations() {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(station -> StationResponse.of(station))
+                .map(StationResponse::of)
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public void deleteStationById(Long id) {
         stationRepository.deleteById(id);
     }

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -15,6 +15,10 @@ public class Station extends BaseEntity {
     public Station() {
     }
 
+    public Station(Long id) {
+        this.id = id;
+    }
+
     public Station(String name) {
         this.name = name;
     }

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -18,10 +18,6 @@ public class Station extends BaseEntity {
 	public Station() {
 	}
 
-	public Station(Long id) {
-		this.id = id;
-	}
-
 	public Station(String name) {
 		this.name = name;
 	}

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -1,33 +1,63 @@
 package nextstep.subway.station.domain;
 
+import java.util.Objects;
+
 import nextstep.subway.common.BaseEntity;
+import nextstep.subway.line.domain.Line;
 
 import javax.persistence.*;
 
 @Entity
 public class Station extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    @Column(unique = true)
-    private String name;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(unique = true)
+	private String name;
 
-    public Station() {
-    }
+	public Station() {
+	}
 
-    public Station(Long id) {
-        this.id = id;
-    }
+	public Station(Long id) {
+		this.id = id;
+	}
 
-    public Station(String name) {
-        this.name = name;
-    }
+	public Station(String name) {
+		this.name = name;
+	}
 
-    public Long getId() {
-        return id;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof Line)) {
+			return false;
+		}
+
+		Station station = (Station)o;
+		return Objects.equals(getId(), station.getId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId());
+	}
+
+	@Override
+	public String toString() {
+		return "Station{" +
+			"id=" + id +
+			", name='" + name + '\'' +
+			'}';
+	}
 }

--- a/src/main/java/nextstep/subway/station/ui/StationController.java
+++ b/src/main/java/nextstep/subway/station/ui/StationController.java
@@ -35,9 +35,4 @@ public class StationController {
         stationService.deleteStationById(id);
         return ResponseEntity.noContent().build();
     }
-
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity handleIllegalArgsException(DataIntegrityViolationException e) {
-        return ResponseEntity.badRequest().build();
-    }
 }

--- a/src/main/java/nextstep/subway/station/ui/StationController.java
+++ b/src/main/java/nextstep/subway/station/ui/StationController.java
@@ -3,6 +3,7 @@ package nextstep.subway.station.ui;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.dto.StationRequest;
 import nextstep.subway.station.dto.StationResponse;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,26 +14,26 @@ import java.util.List;
 
 @RestController
 public class StationController {
-    private StationService stationService;
+	private StationService stationService;
 
-    public StationController(StationService stationService) {
-        this.stationService = stationService;
-    }
+	public StationController(StationService stationService) {
+		this.stationService = stationService;
+	}
 
-    @PostMapping("/stations")
-    public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
-        StationResponse station = stationService.saveStation(stationRequest);
-        return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
-    }
+	@PostMapping("/stations")
+	public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
+		StationResponse station = stationService.saveStation(stationRequest);
+		return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
+	}
 
-    @GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<StationResponse>> showStations() {
-        return ResponseEntity.ok().body(stationService.findAllStations());
-    }
+	@GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<List<StationResponse>> showStations() {
+		return ResponseEntity.ok().body(stationService.findAllStations());
+	}
 
-    @DeleteMapping("/stations/{id}")
-    public ResponseEntity deleteStation(@PathVariable Long id) {
-        stationService.deleteStationById(id);
-        return ResponseEntity.noContent().build();
-    }
+	@DeleteMapping("/stations/{id}")
+	public ResponseEntity deleteStation(@PathVariable Long id) {
+		stationService.deleteStationById(id);
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/src/main/java/nextstep/subway/station/ui/StationController.java
+++ b/src/main/java/nextstep/subway/station/ui/StationController.java
@@ -4,7 +4,6 @@ import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.dto.StationRequest;
 import nextstep.subway.station.dto.StationResponse;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +12,7 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
+@RequestMapping("/stations")
 public class StationController {
 	private StationService stationService;
 
@@ -20,18 +20,23 @@ public class StationController {
 		this.stationService = stationService;
 	}
 
-	@PostMapping("/stations")
+	@PostMapping
 	public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
 		StationResponse station = stationService.saveStation(stationRequest);
 		return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
 	}
 
-	@GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<StationResponse>> showStations() {
 		return ResponseEntity.ok().body(stationService.findAllStations());
 	}
 
-	@DeleteMapping("/stations/{id}")
+	@GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<StationResponse> showStation(@PathVariable Long id) {
+		return ResponseEntity.ok().body(stationService.findStationById(id));
+	}
+
+	@DeleteMapping("/{id}")
 	public ResponseEntity deleteStation(@PathVariable Long id) {
 		stationService.deleteStationById(id);
 		return ResponseEntity.noContent().build();

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("지하철 노선 관련 기능")
 // @Transactional
@@ -27,8 +26,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
 	private static final String LINE_SERVICE_PATH = "/lines";
 
 	//	given
-	public static final Map<String, String> 신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600",1L,2L,10);
-	public static final Map<String, String> 이호선_정보 = 지하철_노선_정보_정의("2호", "bg-이호선_정보-600",1L,2L,10);
+	public static final Map<String, String> 신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600", 1L, 2L, 10);
+	public static final Map<String, String> 이호선_정보 = 지하철_노선_정보_정의("2호", "bg-green-600", 1L, 2L, 10);
 
 	@BeforeEach
 	public void setUpLineAcceptance() {
@@ -84,9 +83,9 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
-		ExtractableResponse<Response> 신분당선_조회_결과 = 지하철_노선_조회(신분당선_요청_경로);
+		ExtractableResponse<Response> 신분당선_조회_결과 = AcceptanceTestFactory.get(신분당선_요청_경로);
 
-		// then
+		//then
 		정상_처리_확인(신분당선_조회_결과);
 		생성된_지하철_노선이_응답에_포함되어있는_확인(신분당선_조회_결과, 신분당선_요청_경로);
 	}
@@ -112,7 +111,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
-		Map<String, String> 신분당선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600",1L,2L,10);
+		Map<String, String> 신분당선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600", 1L, 2L, 10);
 		ExtractableResponse<Response> 신분당선_수정_결과 = 지하철_노선_수정(신분당선_수정정보, 신분당선_요청_경로);
 
 		// then
@@ -130,7 +129,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 미등록_노선_요청_경로 = LINE_SERVICE_PATH + "/1";
 
 		// when
-		Map<String, String> 미등록_노선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600",1L,2L,10);
+		Map<String, String> 미등록_노선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600", 1L, 2L, 10);
 		ExtractableResponse<Response> 미등록_노선_수정_결과 = 지하철_노선_수정(미등록_노선_수정정보, 미등록_노선_요청_경로);
 
 		// then
@@ -151,8 +150,9 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		삭제_완료_확인(신분당선_삭제_결과);
 	}
 
-	private static Map<String, String> 지하철_노선_정보_정의(String name, String color,Long upStationId, Long downStationId, int distance) {
-		return AcceptanceTestFactory.getLineInfo(name, color,upStationId,downStationId,distance);
+	private static Map<String, String> 지하철_노선_정보_정의(String name, String color, Long upStationId, Long downStationId,
+		int distance) {
+		return AcceptanceTestFactory.getLineInfo(name, color, upStationId, downStationId, distance);
 	}
 
 	private ExtractableResponse<Response> 지하철_노선_생성(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -29,8 +29,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
 	@BeforeEach
 	public void setUpLineAcceptance() {
 		//	given
-		신분당선_정보 = 지하철_노선_이름과_색깔_정의("신분당선", "bg-red-600");
-		이호선_정보 = 지하철_노선_이름과_색깔_정의("2호", "bg-이호선_정보-600");
+		신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600",1L,2L,10);
+		이호선_정보 = 지하철_노선_정보_정의("2호", "bg-이호선_정보-600",1L,2L,10);
 	}
 
 	@DisplayName("지하철 노선을 생성한다.")
@@ -108,7 +108,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
-		Map<String, String> 신분당선_수정정보 = 지하철_노선_이름과_색깔_정의("구분당", "bg-blue-600");
+		Map<String, String> 신분당선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600",1L,2L,10);
 		ExtractableResponse<Response> 신분당선_수정_결과 = 지하철_노선_수정(신분당선_수정정보, 신분당선_요청_경로);
 
 		// then
@@ -126,7 +126,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 미등록_노선_요청_경로 = LINE_SERVICE_PATH + "/1";
 
 		// when
-		Map<String, String> 미등록_노선_수정정보 = 지하철_노선_이름과_색깔_정의("구분당", "bg-blue-600");
+		Map<String, String> 미등록_노선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600",1L,2L,10);
 		ExtractableResponse<Response> 미등록_노선_수정_결과 = 지하철_노선_수정(미등록_노선_수정정보, 미등록_노선_요청_경로);
 
 		// then
@@ -147,8 +147,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		삭제_완료_확인(신분당선_삭제_결과);
 	}
 
-	private static Map<String, String> 지하철_노선_이름과_색깔_정의(String name, String color) {
-		return AcceptanceTestFactory.getNameAndColorContent(name, color);
+	private static Map<String, String> 지하철_노선_정보_정의(String name, String color,Long upStationId, Long downStationId, int distance) {
+		return AcceptanceTestFactory.getLineInfo(name, color,upStationId,downStationId,distance);
 	}
 
 	private ExtractableResponse<Response> 지하철_노선_생성(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -11,26 +11,30 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("지하철 노선 관련 기능")
+// @Transactional
 public class LineAcceptanceTest extends AcceptanceTest {
 
 	private static final String LINE_SERVICE_PATH = "/lines";
 
-	private Map<String, String> 신분당선_정보;
-	private Map<String, String> 이호선_정보;
+	//	given
+	public static final Map<String, String> 신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600",1L,2L,10);
+	public static final Map<String, String> 이호선_정보 = 지하철_노선_정보_정의("2호", "bg-이호선_정보-600",1L,2L,10);
 
 	@BeforeEach
 	public void setUpLineAcceptance() {
 		//	given
-		신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600",1L,2L,10);
-		이호선_정보 = 지하철_노선_정보_정의("2호", "bg-이호선_정보-600",1L,2L,10);
+		StationAcceptanceTest.지하철역_생성(StationAcceptanceTest.강남역_정보);
+		StationAcceptanceTest.지하철역_생성(StationAcceptanceTest.역삼역_정보);
 	}
 
 	@DisplayName("지하철 노선을 생성한다.")

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -6,8 +6,6 @@ import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -51,7 +49,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
 		예외_발생_확인(강남역_중복_생성_결과);
 	}
 
-	@DisplayName("지하철역을 조회한다.")
+	@DisplayName("지하철역 목록을 조회한다.")
 	@Test
 	void getStations() {
 		// given
@@ -64,6 +62,25 @@ public class StationAcceptanceTest extends AcceptanceTest {
 		// then
 		정상_처리_확인(지하철역_목록_결과);
 		생성된_지하철역이_응답_목록에_포함되어있는_확인(Arrays.asList(강남역_생성_되어있음, 역삼역_생성_되어있음), 지하철역_목록_결과);
+	}
+
+	@DisplayName("특정 지하철역을 조회한다.")
+	@Test
+	void getStation() {
+		// given
+		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
+		String 강남역_요청_경로 = 강남역_생성_되어있음.header("Location");
+		// when
+		ExtractableResponse<Response> 강남역_조회_결과 = 지하철역_조회(강남역_요청_경로);
+
+		// then
+		정상_처리_확인(강남역_조회_결과);
+		생성된_지하철역이_응답에_포함되어있는_확인(강남역_조회_결과, 강남역_요청_경로);
+	}
+
+	private void 생성된_지하철역이_응답에_포함되어있는_확인(ExtractableResponse<Response> response, String createdUri) {
+		assertThat(response.jsonPath().getObject(".", LineResponse.class).getId()).isEqualTo(
+			Long.parseLong(createdUri.split("/")[2]));
 	}
 
 	@DisplayName("지하철역을 제거한다.")

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -6,6 +6,7 @@ import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,15 +24,9 @@ public class StationAcceptanceTest extends AcceptanceTest {
 
 	private static final String STATION_SERVICE_PATH = "/stations";
 
-	private Map<String, String> 강남역_정보;
-	private Map<String, String> 역삼역_정보;
-
-	@BeforeEach
-	public void setUpStationAcceptance() {
-		//	given
-		강남역_정보 = 지하철역_이름_정의("강남역");
-		역삼역_정보 = 지하철역_이름_정의("역삼역");
-	}
+	//	given
+	public static final Map<String, String> 강남역_정보 = 지하철역_이름_정의("강남역");
+	public static final Map<String, String> 역삼역_정보 = 지하철역_이름_정의("역삼역");
 
 	@DisplayName("지하철역을 생성한다.")
 	@Test
@@ -85,11 +80,11 @@ public class StationAcceptanceTest extends AcceptanceTest {
 		삭제_완료_확인(강남역_삭제_결과);
 	}
 
-	private static Map<String, String> 지하철역_이름_정의(String name) {
+	public static Map<String, String> 지하철역_이름_정의(String name) {
 		return AcceptanceTestFactory.getNameContent(name);
 	}
 
-	private ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
+	public static ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
 		return AcceptanceTestFactory.post(params, STATION_SERVICE_PATH);
 	}
 

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -3,15 +3,15 @@ package nextstep.subway.station;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.station.dto.StationResponse;
+import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,72 +21,111 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
 
-    private static final String stationServicePath="/stations";
+	private static final String STATION_SERVICE_PATH = "/stations";
 
-    @DisplayName("지하철역을 생성한다.")
-    @Test
-    void createStation() {
-        // given
-        Map<String, String> params = AcceptanceTestFactory.getNameContent("강남역");
+	private Map<String, String> 강남역_정보;
+	private Map<String, String> 역삼역_정보;
 
-        // when
-        ExtractableResponse<Response> response =  AcceptanceTestFactory.post(params,stationServicePath);
+	@BeforeEach
+	public void setUpStationAcceptance() {
+		//	given
+		강남역_정보 = 지하철역_이름_정의("강남역");
+		역삼역_정보 = 지하철역_이름_정의("역삼역");
+	}
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
-    }
+	@DisplayName("지하철역을 생성한다.")
+	@Test
+	void createStation() {
+		// when
+		ExtractableResponse<Response> 강남역_생성_결과 = 지하철역_생성(강남역_정보);
 
-    @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
-    @Test
-    void createStationWithDuplicateName() {
-        // given
-        Map<String, String> params = AcceptanceTestFactory.getNameContent("강남역");
-        AcceptanceTestFactory.post(params,stationServicePath);
+		// then
+		정상_생성_확인(강남역_생성_결과);
+	}
 
-        // when
-        ExtractableResponse<Response> response = AcceptanceTestFactory.post(params,stationServicePath);
+	@DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
+	@Test
+	void createStationWithDuplicateName() {
+		// given
+		지하철역_생성(강남역_정보);
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
+		// when
+		ExtractableResponse<Response> 강남역_중복_생성_결과 = 지하철역_생성(강남역_정보);
 
-    @DisplayName("지하철역을 조회한다.")
-    @Test
-    void getStations() {
-        /// given
-        Map<String, String> params1 = AcceptanceTestFactory.getNameContent("강남역");
-        ExtractableResponse<Response> createResponse1 = AcceptanceTestFactory.post(params1,stationServicePath);
-        Map<String, String> params2 = AcceptanceTestFactory.getNameContent("역삼역");
-        ExtractableResponse<Response> createResponse2 = AcceptanceTestFactory.post(params2,stationServicePath);
+		// then
+		예외_발생_확인(강남역_중복_생성_결과);
+	}
 
-        // when
-        ExtractableResponse<Response> response = AcceptanceTestFactory.get(stationServicePath);
+	@DisplayName("지하철역을 조회한다.")
+	@Test
+	void getStations() {
+		// given
+		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 역삼역_생성_되어있음 = 지하철역_생성(역삼역_정보);
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
-                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
-                .collect(Collectors.toList());
-        List<Long> resultLineIds = response.jsonPath().getList(".", StationResponse.class).stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-        assertThat(resultLineIds).containsAll(expectedLineIds);
-    }
+		// when
+		ExtractableResponse<Response> 지하철역_목록_결과 = 지하철역_조회(STATION_SERVICE_PATH);
 
-    @DisplayName("지하철역을 제거한다.")
-    @Test
-    void deleteStation() {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = AcceptanceTestFactory.post(params,stationServicePath);
+		// then
+		정상_처리_확인(지하철역_목록_결과);
+		생성된_지하철역이_응답_목록에_포함되어있는_확인(Arrays.asList(강남역_생성_되어있음, 역삼역_생성_되어있음), 지하철역_목록_결과);
+	}
 
-        // when
-        String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response =  AcceptanceTestFactory.delete(uri);
+	@DisplayName("지하철역을 제거한다.")
+	@Test
+	void deleteStation() {
+		// given
+		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
+		String 강남역_요청_경로 = 강남역_생성_되어있음.header("Location");
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
+		// when
+		ExtractableResponse<Response> 강남역_삭제_결과 = 지하철역_삭제(강남역_요청_경로);
+
+		// then
+		삭제_완료_확인(강남역_삭제_결과);
+	}
+
+	private static Map<String, String> 지하철역_이름_정의(String name) {
+		return AcceptanceTestFactory.getNameContent(name);
+	}
+
+	private ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
+		return AcceptanceTestFactory.post(params, STATION_SERVICE_PATH);
+	}
+
+	private void 정상_생성_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+		assertThat(response.header("Location")).isNotBlank();
+	}
+
+	private void 예외_발생_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	private ExtractableResponse<Response> 지하철역_조회(String path) {
+		return AcceptanceTestFactory.get(path);
+	}
+
+	private void 생성된_지하철역이_응답_목록에_포함되어있는_확인(List<ExtractableResponse<Response>> registeredStationResponses,
+		ExtractableResponse<Response> response) {
+		List<Long> expectedLineIds = registeredStationResponses.stream()
+			.map(it -> Long.parseLong(it.header("Location").split("/")[2]))
+			.collect(Collectors.toList());
+		List<Long> resultLineIds = response.jsonPath().getList(".", LineResponse.class).stream()
+			.map(it -> it.getId())
+			.collect(Collectors.toList());
+		assertThat(resultLineIds).containsAll(expectedLineIds);
+	}
+
+	private void 정상_처리_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	private ExtractableResponse<Response> 지하철역_삭제(String createdUri) {
+		return AcceptanceTestFactory.delete(createdUri);
+	}
+
+	private void 삭제_완료_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
 }

--- a/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
+++ b/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
@@ -34,26 +34,27 @@ public class AcceptanceTestFactory {
 		return postBase(preBase().delete(path));
 	}
 
-	private static RequestSpecification preBase(Map<String, String> params){
+	private static RequestSpecification preBase(Map<String, String> params) {
 		return RestAssured.given().log().all()
 			.body(params)
 			.contentType(MediaType.APPLICATION_JSON_VALUE)
 			.when();
 	}
 
-	private static RequestSpecification preBase(){
+	private static RequestSpecification preBase() {
 		return RestAssured.given().log().all()
 			.contentType(MediaType.APPLICATION_JSON_VALUE)
 			.when();
 	}
 
-	private static ExtractableResponse<Response> postBase(Response response){
+	private static ExtractableResponse<Response> postBase(Response response) {
 		return response
 			.then().log().all()
 			.extract();
 	}
 
-	public static Map<String, String> getLineInfo(String name, String color, Long upStationId, Long downStationId, int distance) {
+	public static Map<String, String> getLineInfo(String name, String color, Long upStationId, Long downStationId,
+		int distance) {
 		Map<String, String> params = new HashMap<>();
 		params.put("name", name);
 		params.put("color", color);

--- a/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
+++ b/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
@@ -12,13 +12,6 @@ import io.restassured.specification.RequestSpecification;
 
 public class AcceptanceTestFactory {
 
-	public static Map<String, String> getNameAndColorContent(String name, String color) {
-		Map<String, String> params = new HashMap<>();
-		params.put("name", name);
-		params.put("color", color);
-		return params;
-	}
-
 	public static Map<String, String> getNameContent(String name) {
 		Map<String, String> params = new HashMap<>();
 		params.put("name", name);
@@ -58,6 +51,16 @@ public class AcceptanceTestFactory {
 		return response
 			.then().log().all()
 			.extract();
+	}
+
+	public static Map<String, String> getLineInfo(String name, String color, Long upStationId, Long downStationId, int distance) {
+		Map<String, String> params = new HashMap<>();
+		params.put("name", name);
+		params.put("color", color);
+		params.put("upStationId", String.valueOf(upStationId));
+		params.put("downStationId", String.valueOf(downStationId));
+		params.put("distance", String.valueOf(distance));
+		return params;
 	}
 }
 


### PR DESCRIPTION
안녕하세요 지호님 🙂

바쁘실텐데 평일에도 늦게까지 리뷰 봐주셔서 감사드립니다.

전 단계에서 지호님의 조언에 따라 인수테스트의 메서드, 변수명들을 한글로 바꾸어 보았는데요,
처음엔 어색하다 생각하였는데 가독성이 좋아지고 의미가 분명해져서 인수테스트 목적과 사용성에 대해 조금더 이해하게 되었습니다.

이번 단계를 수행하며 Lazy 로딩으로 인한 ResponseEntity의 json Serialize 어려움이 있었습니다.

Lazy 로딩은 실제로 연관관계 참조객체를 호출하기 전에는 프록시 객체를 생성하여 가지고 있다가, 해당 객체를 get과 같은 접근으로 참조하면
그때 쿼리가 나간다고 알고있습니다.
그리고 이때 프록시 타입이 엔티티 타입으로 바뀐다고 생각하였는데... 
알고보니 지연로딩이 실제로 쿼리가 나가고 나서도 타입이 변하진 않고 프록시에서 참조하는 엔티티 객체를가 채워지는 것이더라구요 하핫 😂

이를 해결하기 위해서 각각의 Respository를 이용하여도 되었지만,
단계가 많아지는 불편함과 DB IO가 많아지는 단점이 있어서 한번의 쿼리로 가져올 수 있도록 패치 조인을 적용해보았습니다.

2단계 코드리뷰도 잘 부탁드립니다.😄