### PR TITLE
3단계 - 구간 추가 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### # 1단계 : 지하철 노선도 관리
 
 #### 요구 사항
-
+ 
 - 지하철 노선 관리 기능을 구현하기
     - 기능 목록: 생성 / 목록 조회 / 조회 / 수정 / 삭제
     - 기능 구현 전 인수 테스트 작성
@@ -59,65 +59,6 @@ public class LineController {
 인수 테스트의 각 스텝들을 메서드로 분리하여 재사용하세요.
 ex) 인수 테스트 요청 로직 중복 제거 등# 우아한 테크 캠프 Pro - 미션 3
 
-## 미션명 : ATDD(인수 테스트 주도 개발)
-
-### # 1단계 : 지하철 노선도 관리
-
-#### 요구 사항
-
-- 지하철 노선 관리 기능을 구현하기
-    - 기능 목록: 생성 / 목록 조회 / 조회 / 수정 / 삭제
-    - 기능 구현 전 인수 테스트 작성
-    - 기능 구현 후 인수 테스트 리팩터링
-
-#### 단계별 요구사항
-
-**1.지하철 노선 관련 기능의 인수 테스트를 작성하기**
-- LineAcceptanceTest 를 모두 완성시키세요.
-```java
-@DisplayName("지하철 노선 관련 기능")
-public class LineAcceptanceTest extends AcceptanceTest {
-    @DisplayName("지하철 노선을 생성한다.")
-    @Test
-    void createLine() {
-        // when
-        // 지하철_노선_생성_요청
-
-        // then
-        // 지하철_노선_생성됨
-    }
-
-    ...
-}
-```
-
-
-**2.지하철 노선 관련 기능 구현하기**
-- 인수 테스트가 모두 성공할 수 있도록 LineController를 통해 요청을 받고 처리하는 기능을 구현하세요.
-```java
-@RestController
-@RequestMapping("/lines")
-public class LineController {
-
-    ...
-
-	@PostMapping
-	public ResponseEntity createLine(@RequestBody LineRequest lineRequest) {
-		// TODO
-	}
-
-	@GetMapping
-	public ResponseEntity<List<LineResponse>> findAllLines() {
-		// TODO
-	}
-    
-    ...
-}
-```
-**3.인수 테스트 리팩터링**
-인수 테스트의 각 스텝들을 메서드로 분리하여 재사용하세요.
-ex) 인수 테스트 요청 로직 중복 제거 등
-
 
 ### # 2단계 : 인수 테스트 리팩터링
 
@@ -159,3 +100,39 @@ public class Line {
 - 노선 조회 시 역 목록을 함께 응답할 수 있도록 변경
 - 노선에 등록된 구간을 순서대로 정렬하여(상행역 부터 하행역 순) 상행 종점부터 하행 종점까지 목록을 응답하기
 - 필요시 노선과 구간(혹은 역)의 관계를 새로 맺기
+
+
+### # 3단계 : 구간 추가 기능
+
+#### 요구 사항
+
+1. 지하철 구간 등록 성공 인수 테스트 작성과 기능 구현
+
+- 역 사이에 새로운 역을 등록할 경우
+    - 새로운 길이를 뺀 나머지를 새롭게 추가된 역과의 길이로 설정
+- 새로운 역을 상행 종점으로 등록할 경우
+- 새로운 역을 하행 종점으로 등록할 경우
+
+2. 구간 등록 시 예외 케이스를 고려하여 인수테스트 작성
+
+- 역 사이에 새로운 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 등록을 할 수 없음
+- 상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가할 수 없음
+    - A-B, B-C 구간이 등록된 상황에서 B-C 구간을 등록할 수 없음(A-C 구간도 등록할 수 없음
+    - 상행역과 하행역 둘 중 하나도 포함되어있지 않으면 추가할 수 없음
+
+
+
+#### 요청 Request 포맷
+
+```json
+POST /lines/1/sections HTTP/1.1
+accept: */*
+content-type: application/json; charset=UTF-8
+host: localhost:52165
+
+{
+    "downStationId": "4",
+    "upStationId": "2",
+    "distance": 10
+}
+```

--- a/src/main/java/nextstep/subway/common/SubwayExceptionHandler.java
+++ b/src/main/java/nextstep/subway/common/SubwayExceptionHandler.java
@@ -18,4 +18,9 @@ public class SubwayExceptionHandler {
 		return ResponseEntity.badRequest().build();
 	}
 
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity handleIllegalStateException(IllegalStateException e) {
+		return ResponseEntity.badRequest().build();
+	}
+
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -23,15 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class LineService {
 
 	private final LineRepository lineRepository;
-	private final SectionRepository sectionRepository;
 
 	/*	Station은 도메인이 다르므로  StationRepository를 바로 접근하지 않고 StationService 계층을 통해서 접근	*/
 	private final StationService stationService;
 
-	public LineService(LineRepository lineRepository, SectionRepository sectionRepository,
-		StationService stationService) {
+	public LineService(LineRepository lineRepository, StationService stationService) {
 		this.lineRepository = lineRepository;
-		this.sectionRepository = sectionRepository;
 		this.stationService = stationService;
 	}
 
@@ -42,12 +39,11 @@ public class LineService {
 
 		Line persistLine = lineRepository.save(request.toLine());
 		Section endToend = new Section(upStation, downStation, request.getDistance());
-		sectionRepository.save(endToend);
 		persistLine.addSection(endToend);
 		return LineResponse.from(persistLine);
 	}
 
-	public List<LineResponse> findAllLineWithSections(){
+	public List<LineResponse> findAllLineWithSections() {
 		List<Line> lines = lineRepository.findAllLinesWithSectionsAndStations();
 		return lines.stream()
 			.map(LineResponse::from)
@@ -56,18 +52,17 @@ public class LineService {
 
 	@Transactional
 	public void deleteLineById(Long id) {
-		sectionRepository.deleteAllByLineId(id);
 		lineRepository.deleteById(id);
 	}
 
-	public LineResponse findLineWithSectionsById(Long id){
+	public LineResponse findLineWithSectionsById(Long id) {
 		Line line = lineRepository.findLineWithSectionsAndStationsById(id);
 		validateExistLine(line);
 		return LineResponse.from(line);
 	}
 
 	private void validateExistLine(Line line) {
-		if(line == null){
+		if (line == null) {
 			throw new IllegalArgumentException("없는 노선입니다.");
 		}
 	}
@@ -84,7 +79,7 @@ public class LineService {
 	}
 
 	@Transactional
-	public SectionResponse addSection(Long lineId, SectionRequest sectionRequest) {
+	public LineResponse addSection(Long lineId, SectionRequest sectionRequest) {
 		Line line = lineRepository.findLineWithSectionsAndStationsById(lineId);
 
 		Station upStation = stationService.getStationEntity(sectionRequest.getUpStationId());
@@ -92,7 +87,6 @@ public class LineService {
 		Section section = new Section(upStation, downStation, sectionRequest.getDistance());
 
 		line.addSection(section);
-		Section persistenceSection = sectionRepository.save(section);
-		return SectionResponse.from(persistenceSection);
+		return LineResponse.from(line);
 	}
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -7,11 +7,9 @@ import java.util.stream.Collectors;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.domain.Section;
-import nextstep.subway.line.domain.SectionRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.line.dto.SectionRequest;
-import nextstep.subway.line.dto.SectionResponse;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -8,7 +8,6 @@ import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.domain.SectionRepository;
-import nextstep.subway.line.domain.Sections;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.application.StationService;
@@ -43,20 +42,20 @@ public class LineService {
 		Line persistLine = lineRepository.save(request.toLine());
 		Section endToend = new Section(persistLine, upStation, downStation, request.getDistance());
 		sectionRepository.save(endToend);
-		return LineResponse.of(persistLine);
+		return LineResponse.from(persistLine);
 	}
 
 	public List<LineResponse> findAllLines() {
 		List<Line> lines = lineRepository.findAll();
 		return lines.stream()
-			.map(LineResponse::of)
+			.map(LineResponse::from)
 			.collect(Collectors.toList());
 	}
 
 	public List<LineResponse> findAllLineWithSections(){
 		List<Line> lines = lineRepository.findAllLinesWithSectionsAndStations();
 		return lines.stream()
-			.map(LineResponse::of)
+			.map(LineResponse::from)
 			.collect(Collectors.toList());
 	}
 
@@ -68,13 +67,13 @@ public class LineService {
 
 	public LineResponse findLineById(Long id) {
 		Line line = getLine(id);
-		return LineResponse.of(line);
+		return LineResponse.from(line);
 	}
 
 	public LineResponse findLineWithSectionsById(Long id){
 		Line line = lineRepository.findLineWithSectionsAndStationsById(id);
 		validateExistLine(line);
-		return LineResponse.of(line);
+		return LineResponse.from(line);
 	}
 
 	private void validateExistLine(Line line) {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -36,8 +36,8 @@ public class LineService {
 		Station downStation = stationService.getStationEntity(request.getDownStationId());
 
 		Line persistLine = lineRepository.save(request.toLine());
-		Section endToend = new Section(upStation, downStation, request.getDistance());
-		persistLine.addSection(endToend);
+		Section section = new Section(upStation, downStation, request.getDistance());
+		persistLine.addSection(section);
 		return LineResponse.from(persistLine);
 	}
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -10,6 +10,8 @@ import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.domain.SectionRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
+import nextstep.subway.line.dto.SectionResponse;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
 
@@ -35,21 +37,14 @@ public class LineService {
 
 	@Transactional
 	public LineResponse saveLine(LineRequest request) {
-
 		Station upStation = stationService.getStationEntity(request.getUpStationId());
 		Station downStation = stationService.getStationEntity(request.getDownStationId());
 
 		Line persistLine = lineRepository.save(request.toLine());
-		Section endToend = new Section(persistLine, upStation, downStation, request.getDistance());
+		Section endToend = new Section(upStation, downStation, request.getDistance());
 		sectionRepository.save(endToend);
+		persistLine.addSection(endToend);
 		return LineResponse.from(persistLine);
-	}
-
-	public List<LineResponse> findAllLines() {
-		List<Line> lines = lineRepository.findAll();
-		return lines.stream()
-			.map(LineResponse::from)
-			.collect(Collectors.toList());
 	}
 
 	public List<LineResponse> findAllLineWithSections(){
@@ -63,11 +58,6 @@ public class LineService {
 	public void deleteLineById(Long id) {
 		sectionRepository.deleteAllByLineId(id);
 		lineRepository.deleteById(id);
-	}
-
-	public LineResponse findLineById(Long id) {
-		Line line = getLine(id);
-		return LineResponse.from(line);
 	}
 
 	public LineResponse findLineWithSectionsById(Long id){
@@ -91,5 +81,18 @@ public class LineService {
 	private Line getLine(Long id) {
 		Optional<Line> findLine = lineRepository.findById(id);
 		return findLine.orElseThrow(() -> new IllegalArgumentException("없는 노선입니다."));
+	}
+
+	@Transactional
+	public SectionResponse addSection(Long lineId, SectionRequest sectionRequest) {
+		Line line = lineRepository.findLineWithSectionsAndStationsById(lineId);
+
+		Station upStation = stationService.getStationEntity(sectionRequest.getUpStationId());
+		Station downStation = stationService.getStationEntity(sectionRequest.getDownStationId());
+		Section section = new Section(upStation, downStation, sectionRequest.getDistance());
+
+		line.addSection(section);
+		Section persistenceSection = sectionRepository.save(section);
+		return SectionResponse.from(persistenceSection);
 	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -18,7 +18,7 @@ public class Line extends BaseEntity {
 	@Embedded
 	private Sections sections = new Sections();
 
-	public Line() {
+	protected Line() {
 	}
 
 	public Line(String name, String color) {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -11,8 +11,10 @@ public class Line extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
 	@Column(unique = true)
 	private String name;
+
 	private String color;
 
 	@Embedded

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -29,7 +29,7 @@ public class Line extends BaseEntity {
 	}
 
 	public void addSection(Section section) {
-		sections.add(section);
+		sections.addSection(section,this);
 	}
 
 	public void update(Line line) {

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -62,10 +62,6 @@ public class Section {
 		return downStation;
 	}
 
-	public int getDistance() {
-		return distance;
-	}
-
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -37,13 +37,14 @@ public class Section {
 	protected Section() {
 	}
 
-	public Section(Line line, Station upStation, Station downStation, int distance) {
-		this.line = line;
+	public Section(Station upStation, Station downStation, int distance) {
 		this.upStation = upStation;
 		this.downStation = downStation;
 		this.distance = distance;
+	}
 
-		line.addSection(this);
+	public void assignLine(Line line){
+		this.line = line;
 	}
 
 	public Long getId() {
@@ -60,6 +61,10 @@ public class Section {
 
 	public Station getDownStation() {
 		return downStation;
+	}
+
+	public int getDistance() {
+		return distance;
 	}
 
 	@Override
@@ -89,4 +94,11 @@ public class Section {
 			'}';
 	}
 
+	public void changeDownSection(Station station) {
+		this.downStation=station;
+	}
+
+	public void changeDistance(int distance) {
+		this.distance=distance;
+	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -67,6 +67,28 @@ public class Section {
 		return distance;
 	}
 
+	public void minusDistance(int distance) {
+		this.distance -= distance;
+	}
+
+	public boolean matchUpStation(Station station) {
+		return upStation.equals(station);
+	}
+
+	public void splitUpSection(Section newPreSection) {
+		this.upStation = newPreSection.getDownStation();
+		minusDistance(newPreSection.getDistance());
+	}
+
+	public boolean matchDownStation(Station station) {
+		return downStation.equals(station);
+	}
+
+	public void splitDownSection(Section newPreSection) {
+		this.downStation = newPreSection.getUpStation();
+		minusDistance(newPreSection.getDistance());
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -94,11 +116,5 @@ public class Section {
 			'}';
 	}
 
-	public void changeDownSection(Station station) {
-		this.downStation=station;
-	}
 
-	public void changeDistance(int distance) {
-		this.distance=distance;
-	}
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -34,7 +34,7 @@ public class Section {
 
 	private int distance;
 
-	public Section() {
+	protected Section() {
 	}
 
 	public Section(Line line, Station upStation, Station downStation, int distance) {

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -1,8 +1,0 @@
-package nextstep.subway.line.domain;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface SectionRepository extends JpaRepository<Section, Long> {
-
-	void deleteAllByLineId(Long lineId);
-}

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -45,14 +45,15 @@ public class Sections {
 
 	private Map<Station, Station> getUpDownRoute() {
 		return sections.stream()
-			.collect(Collectors.toMap(entry -> entry.getUpStation(), entry -> entry.getDownStation(),
-				(o1, o2) -> o1, HashMap::new));
+			.collect(Collectors.toMap(Section::getUpStation, Section::getDownStation, (o1, o2) -> o1, HashMap::new));
 	}
 
 	private Station findStartStation() {
-		Set<Station> downStations = sections.stream().map(it -> it.getDownStation()).collect(Collectors.toSet());
+		Set<Station> downStations = sections.stream()
+			.map(Section::getDownStation)
+			.collect(Collectors.toSet());
 		Optional<Station> notDownStation = sections.stream()
-			.map(it -> it.getUpStation())
+			.map(Section::getUpStation)
 			.filter(it -> !downStations.contains(it))
 			.findFirst();
 		return notDownStation.orElseThrow(() -> new IllegalStateException("구간 정보가 올바르지 않습니다."));

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -22,16 +22,8 @@ public class Sections {
 	protected Sections() {
 	}
 
-	public Sections(List<Section> sections) {
-		this.sections = sections;
-	}
-
 	public void add(Section section) {
 		sections.add(section);
-	}
-
-	public List<Section> getSections() {
-		return sections;
 	}
 
 	public List<Station> getStations() {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -2,12 +2,14 @@ package nextstep.subway.line.domain;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 
@@ -16,32 +18,131 @@ import nextstep.subway.station.domain.Station;
 @Embeddable
 public class Sections {
 
-	@OneToMany(mappedBy = "line")
+	@OneToMany(mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Section> sections = new ArrayList<>();
 
 	protected Sections() {
 	}
 
-	public void add(Section section) {
-		sections.add(section);
+	public boolean isEmpty() {
+		return sections.size() == 0;
 	}
 
-	public List<Station> getStations() {
+	private void add(Section requestSection, Line line) {
+		sections.add(requestSection);
+		requestSection.assignLine(line);
+	}
+
+	public void addSection(Section requestSection, Line line) {
+		if (isEmpty()) {
+			add(requestSection, line);
+			return;
+		}
+
+		validateInsertSection(requestSection);
 
 		List<Section> orderedSections = getOrderedSections();
-		return converToStations(orderedSections);
+		Section firstSection = orderedSections.get(0);
+		Section lastSection = orderedSections.get(orderedSections.size() - 1);
+
+		Section insertSection = null;
+
+		for (Section currentSection : orderedSections) {
+			if (currentSection.getUpStation() == requestSection.getUpStation()) { // 상행선 맞닿음
+				validateInsertableLengthBetween(currentSection, requestSection);
+
+				insertSection = new Section(requestSection.getDownStation(),
+					currentSection.getDownStation(), currentSection.getDistance() - requestSection.getDistance());
+				currentSection.changeDownSection(requestSection.getDownStation());
+				currentSection.changeDistance(requestSection.getDistance());
+				break;
+			}
+
+			if (currentSection.getDownStation() == requestSection.getDownStation()) { // 하행선 맞닿음
+				validateInsertableLengthBetween(currentSection, requestSection);
+
+				insertSection = new Section(requestSection.getUpStation(),
+					currentSection.getDownStation(), requestSection.getDistance());
+				currentSection.changeDownSection(requestSection.getUpStation());
+				currentSection.changeDistance(currentSection.getDistance() - requestSection.getDistance());
+				break;
+			}
+
+			if (currentSection.getUpStation() == requestSection.getDownStation()) { // 새로운 상행 종점
+				if (!currentSection.equals(firstSection)) {
+					continue;
+				}
+
+				insertSection = new Section(requestSection.getUpStation(),
+					requestSection.getDownStation(), requestSection.getDistance());
+				break;
+			}
+
+			if (currentSection.getDownStation() == requestSection.getUpStation()) { // 새로운 상행 종점
+				if (!currentSection.equals(lastSection)) {
+					continue;
+				}
+
+				insertSection = new Section(requestSection.getUpStation(),
+					requestSection.getDownStation(), requestSection.getDistance());
+				break;
+			}
+		}
+		add(insertSection, line);
 	}
 
-	private List<Station> converToStations(List<Section> orderedSections) {
-		List<Station> stations = new ArrayList<>();
-		for(Section section : orderedSections){
+	private void validateInsertSection(Section requestSection) {
+		Set<Station> stations = getStations();
+
+		Boolean hasUpStation = false;
+		Boolean hasDownStation = false;
+		if (stations.contains(requestSection.getUpStation())) {
+			hasUpStation = true;
+		}
+		if (stations.contains(requestSection.getDownStation())) {
+			hasDownStation = true;
+		}
+
+		if (hasUpStation && hasDownStation) {
+			throw new IllegalArgumentException("이미 있는 구간 입니다.");
+
+		}
+
+		if (!hasUpStation && !hasDownStation) {
+			throw new IllegalArgumentException("해당 노선에 추가할 수 없는 구간 정보입니다.");
+		}
+	}
+
+	private void validateInsertableLengthBetween(Section currentSection, Section requestSection) {
+		if (currentSection.getDistance() <= requestSection.getDistance()) { // 기존 역 사이 길이보다 크거나 같으면 등록 불가 예외 발생
+			throw new IllegalArgumentException("기존 역 사이 길이와 같거나 긴 구간은 등록이 불가합니다.");
+		}
+	}
+
+	private Set<Station> getStations() {
+		Set<Station> stations = new HashSet<>();
+		for (Section section : sections) {
 			stations.add(section.getUpStation());
 			stations.add(section.getDownStation());
 		}
 		return stations;
 	}
 
-	public List<Section> getOrderedSections(){
+	public List<Station> getOrderedStatons() {
+		List<Section> orderedSections = getOrderedSections();
+		return converToStations(orderedSections);
+	}
+
+	private List<Station> converToStations(List<Section> orderedSections) {
+		List<Station> stations = new ArrayList<>();
+		for (Section section : orderedSections) {
+			stations.add(section.getUpStation());
+		}
+		stations.add(orderedSections.get(orderedSections.size() - 1).getDownStation());
+		return stations;
+	}
+
+	public List<Section> getOrderedSections() {
 		Section startSection = findStartStation();
 		return orderedSections(startSection);
 	}
@@ -51,7 +152,7 @@ public class Sections {
 		List<Section> sections = new ArrayList<>();
 
 		Section nextSection = startSection;
-		while (nextSection!=null) {
+		while (nextSection != null) {
 			sections.add(nextSection);
 			Station curDownStation = nextSection.getDownStation();
 			nextSection = upStationAndSectionRoute.get(curDownStation);
@@ -61,7 +162,7 @@ public class Sections {
 
 	private Map<Station, Section> getSectionRoute() {
 		return sections.stream()
-			.collect(Collectors.toMap(Section::getUpStation,it->it, (o1, o2) -> o1, HashMap::new));
+			.collect(Collectors.toMap(Section::getUpStation, it -> it, (o1, o2) -> o1, HashMap::new));
 	}
 
 	private Section findStartStation() {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -19,7 +19,7 @@ public class Sections {
 	@OneToMany(mappedBy = "line")
 	private List<Section> sections = new ArrayList<>();
 
-	public Sections() {
+	protected Sections() {
 	}
 
 	public Sections(List<Section> sections) {

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -29,6 +29,10 @@ public class LineRequest {
         return distance;
     }
 
+    public String getColor() {
+        return color;
+    }
+
     public Line toLine() {
         return new Line(name, color);
     }

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -3,29 +3,18 @@ package nextstep.subway.line.dto;
 import nextstep.subway.line.domain.Line;
 
 public class LineRequest {
+
     private String name;
     private String color;
     private Long upStationId;
     private Long downStationId;
     private int distance;
 
-    public LineRequest() {
-    }
-
-    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
-        this.name = name;
-        this.color = color;
-        this.upStationId = upStationId;
-        this.downStationId = downStationId;
-        this.distance = distance;
+    private LineRequest() {
     }
 
     public String getName() {
         return name;
-    }
-
-    public String getColor() {
-        return color;
     }
 
     public Long getUpStationId() {

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -29,7 +29,7 @@ public class LineResponse {
             this.modifiedDate = modifiedDate;
     }
 
-    public static LineResponse of(Line line) {
+    public static LineResponse from(Line line) {
         return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getSections(), line.getCreatedDate(), line.getModifiedDate());
     }
 

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -39,4 +39,20 @@ public class LineResponse {
     public String getName() {
         return name;
     }
+
+    public String getColor() {
+        return color;
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
 }

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -1,7 +1,6 @@
 package nextstep.subway.line.dto;
 
 import nextstep.subway.line.domain.Line;
-import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.domain.Sections;
 import nextstep.subway.station.domain.Station;
 
@@ -40,6 +39,4 @@ public class LineResponse {
     public String getName() {
         return name;
     }
-
-
 }

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -17,7 +17,7 @@ public class LineResponse {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public LineResponse() {
+    private LineResponse() {
     }
 
     public LineResponse(Long id, String name, String color,Sections sections, LocalDateTime createdDate, LocalDateTime modifiedDate ) {

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -9,50 +9,52 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LineResponse {
-    private Long id;
-    private String name;
-    private String color;
-    private List<Station> stations = new ArrayList<>();
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
+	private Long id;
+	private String name;
+	private String color;
+	private List<Station> stations = new ArrayList<>();
+	private LocalDateTime createdDate;
+	private LocalDateTime modifiedDate;
 
-    private LineResponse() {
-    }
+	private LineResponse() {
+	}
 
-    private LineResponse(Long id, String name, String color,Sections sections, LocalDateTime createdDate, LocalDateTime modifiedDate ) {
-            this.id = id;
-            this.name = name;
-            this.color = color;
-            this.stations = sections.getStations();
-            this.createdDate = createdDate;
-            this.modifiedDate = modifiedDate;
-    }
+	private LineResponse(Long id, String name, String color, Sections sections, LocalDateTime createdDate,
+		LocalDateTime modifiedDate) {
+		this.id = id;
+		this.name = name;
+		this.color = color;
+		this.stations = sections.getOrderedStatons();
+		this.createdDate = createdDate;
+		this.modifiedDate = modifiedDate;
+	}
 
-    public static LineResponse from(Line line) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getSections(), line.getCreatedDate(), line.getModifiedDate());
-    }
+	public static LineResponse from(Line line) {
+		return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getSections(),
+			line.getCreatedDate(), line.getModifiedDate());
+	}
 
-    public Long getId() {
-        return id;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public String getColor() {
-        return color;
-    }
+	public String getColor() {
+		return color;
+	}
 
-    public List<Station> getStations() {
-        return stations;
-    }
+	public List<Station> getStations() {
+		return stations;
+	}
 
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
+	public LocalDateTime getCreatedDate() {
+		return createdDate;
+	}
 
-    public LocalDateTime getModifiedDate() {
-        return modifiedDate;
-    }
+	public LocalDateTime getModifiedDate() {
+		return modifiedDate;
+	}
 }

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -20,18 +20,13 @@ public class LineResponse {
     private LineResponse() {
     }
 
-    public LineResponse(Long id, String name, String color,Sections sections, LocalDateTime createdDate, LocalDateTime modifiedDate ) {
-       this(id,name,color,sections.getStations(),createdDate,modifiedDate);
-    }
-
-    public LineResponse(Long id, String name, String color, List<Station> stations, LocalDateTime createdDate,
-        LocalDateTime modifiedDate) {
-        this.id = id;
-        this.name = name;
-        this.color = color;
-        this.stations = stations;
-        this.createdDate = createdDate;
-        this.modifiedDate = modifiedDate;
+    private LineResponse(Long id, String name, String color,Sections sections, LocalDateTime createdDate, LocalDateTime modifiedDate ) {
+            this.id = id;
+            this.name = name;
+            this.color = color;
+            this.stations = sections.getStations();
+            this.createdDate = createdDate;
+            this.modifiedDate = modifiedDate;
     }
 
     public static LineResponse of(Line line) {

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -24,7 +24,7 @@ public class LineResponse {
 		this.id = id;
 		this.name = name;
 		this.color = color;
-		this.stations = sections.getOrderedStatons();
+		this.stations = sections.getOrderedStations();
 		this.createdDate = createdDate;
 		this.modifiedDate = modifiedDate;
 	}

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -41,19 +41,5 @@ public class LineResponse {
         return name;
     }
 
-    public String getColor() {
-        return color;
-    }
 
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public LocalDateTime getModifiedDate() {
-        return modifiedDate;
-    }
-
-    public List<Station> getStations() {
-        return stations;
-    }
 }

--- a/src/main/java/nextstep/subway/line/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/SectionRequest.java
@@ -1,0 +1,22 @@
+package nextstep.subway.line.dto;
+
+public class SectionRequest {
+	private Long upStationId;         // 상행역 아이디
+	private Long downStationId;       // 하행역 아이디
+	private int distance;             // 거리
+
+	private SectionRequest() {
+	}
+
+	public Long getUpStationId() {
+		return upStationId;
+	}
+
+	public Long getDownStationId() {
+		return downStationId;
+	}
+
+	public int getDistance() {
+		return distance;
+	}
+}

--- a/src/main/java/nextstep/subway/line/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/SectionResponse.java
@@ -1,0 +1,42 @@
+package nextstep.subway.line.dto;
+
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.station.domain.Station;
+
+public class SectionResponse {
+
+	private Long id; // 구간ID
+	private Station upStation;         // 상행역 아이디
+	private Station downStation;       // 하행역 아이디
+	private int distance;             // 거리
+
+	private SectionResponse() {
+	}
+
+	public SectionResponse(Long id, Station upStation, Station downStation, int distance) {
+		this.id = id;
+		this.upStation = upStation;
+		this.downStation = downStation;
+		this.distance = distance;
+	}
+
+	public static SectionResponse from(Section section) {
+		return new SectionResponse(section.getId(), section.getUpStation(), section.getDownStation(), section.getDistance());
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Station getUpStation() {
+		return upStation;
+	}
+
+	public Station getDownStation() {
+		return downStation;
+	}
+
+	public int getDistance() {
+		return distance;
+	}
+}

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -43,17 +43,17 @@ public class LineController {
 	@GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
 		LineResponse lineResponse = lineService.findLineWithSectionsById(id);
-		return new ResponseEntity<>(lineResponse, HttpStatus.OK);
+		return ResponseEntity.ok().body(lineResponse);
 	}
 
 	@PutMapping("/{id}")
-	public ResponseEntity updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+	public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
 		lineService.updateLine(id, lineRequest);
 		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity deleteLine(@PathVariable Long id) {
+	public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
 		lineService.deleteLineById(id);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -3,8 +3,9 @@ package nextstep.subway.line.ui;
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
+import nextstep.subway.line.dto.SectionResponse;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -56,5 +57,11 @@ public class LineController {
 	public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
 		lineService.deleteLineById(id);
 		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/{lineId}/sections")
+	public ResponseEntity<SectionResponse> addSection(@PathVariable Long lineId,	@RequestBody SectionRequest sectionRequest) {
+		SectionResponse section = lineService.addSection(lineId,sectionRequest);
+		return ResponseEntity.created(URI.create("/lines/" + lineId+"/sections/"+section.getId())).body(section);
 	}
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -60,8 +60,8 @@ public class LineController {
 	}
 
 	@PostMapping("/{lineId}/sections")
-	public ResponseEntity<SectionResponse> addSection(@PathVariable Long lineId,	@RequestBody SectionRequest sectionRequest) {
-		SectionResponse section = lineService.addSection(lineId,sectionRequest);
-		return ResponseEntity.created(URI.create("/lines/" + lineId+"/sections/"+section.getId())).body(section);
+	public ResponseEntity<LineResponse> addSection(@PathVariable Long lineId,	@RequestBody SectionRequest sectionRequest) {
+		LineResponse line = lineService.addSection(lineId,sectionRequest);
+		return ResponseEntity.created(URI.create("/lines/" + lineId)).body(line);
 	}
 }

--- a/src/main/java/nextstep/subway/station/application/StationService.java
+++ b/src/main/java/nextstep/subway/station/application/StationService.java
@@ -1,7 +1,5 @@
 package nextstep.subway.station.application;
 
-import nextstep.subway.line.domain.Line;
-import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 import nextstep.subway.station.dto.StationRequest;
@@ -25,14 +23,14 @@ public class StationService {
     @Transactional
     public StationResponse saveStation(StationRequest stationRequest) {
         Station persistStation = stationRepository.save(stationRequest.toStation());
-        return StationResponse.of(persistStation);
+        return StationResponse.from(persistStation);
     }
 
     public List<StationResponse> findAllStations() {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(StationResponse::of)
+                .map(StationResponse::from)
                 .collect(Collectors.toList());
     }
 
@@ -42,7 +40,7 @@ public class StationService {
     }
 
 	public StationResponse findStationById(Long id) {
-        return StationResponse.of(getStationEntity(id));
+        return StationResponse.from(getStationEntity(id));
 	}
 
     public Station getStationEntity(Long id) {

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -15,7 +15,7 @@ public class Station extends BaseEntity {
 	@Column(unique = true)
 	private String name;
 
-	public Station() {
+	protected Station() {
 	}
 
 	public Station(String name) {

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -9,9 +9,11 @@ import javax.persistence.*;
 
 @Entity
 public class Station extends BaseEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
 	@Column(unique = true)
 	private String name;
 

--- a/src/main/java/nextstep/subway/station/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/station/dto/StationResponse.java
@@ -10,18 +10,18 @@ public class StationResponse {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public static StationResponse of(Station station) {
-        return new StationResponse(station.getId(), station.getName(), station.getCreatedDate(), station.getModifiedDate());
+    private StationResponse() {
     }
 
-    public StationResponse() {
-    }
-
-    public StationResponse(Long id, String name, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    private StationResponse(Long id, String name, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.name = name;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+    }
+
+    public static StationResponse from(Station station) {
+        return new StationResponse(station.getId(), station.getName(), station.getCreatedDate(), station.getModifiedDate());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/station/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/station/dto/StationResponse.java
@@ -31,12 +31,4 @@ public class StationResponse {
     public String getName() {
         return name;
     }
-
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public LocalDateTime getModifiedDate() {
-        return modifiedDate;
-    }
 }

--- a/src/main/java/nextstep/subway/station/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/station/dto/StationResponse.java
@@ -31,4 +31,12 @@ public class StationResponse {
     public String getName() {
         return name;
     }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
 }

--- a/src/main/java/nextstep/subway/station/ui/StationController.java
+++ b/src/main/java/nextstep/subway/station/ui/StationController.java
@@ -37,7 +37,7 @@ public class StationController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity deleteStation(@PathVariable Long id) {
+	public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
 		stationService.deleteStationById(id);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -18,7 +18,6 @@ import nextstep.subway.testFactory.AcceptanceTestFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
@@ -32,7 +31,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		"bg-green-600", 1L, 2L, 10);
 
 	@BeforeEach
-	public void setUpLineAcceptance() {
+	public void setUp() {
+		super.setUp();
 		//	given
 		StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보);
 		StationTestFactory.지하철역_생성(StationAcceptanceTest.역삼역_정보);

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -13,6 +13,7 @@ import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.station.StationTestFactory;
+import nextstep.subway.station.dto.StationResponse;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,18 +25,22 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
 	public static final String LINE_SERVICE_PATH = "/lines";
 
-	//	given
-	public static final Map<String, String> 신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선",
-		"bg-red-600", 1L, 2L, 10);
-	public static final Map<String, String> 이호선_정보 = LineTestFactory.지하철_노선_정보_정의("2호",
-		"bg-green-600", 1L, 2L, 10);
+	private StationResponse 강남역;
+	private StationResponse 역삼역;
+	private Map<String, String> 신분당선_정보;
+	private Map<String, String> 이호선_정보;
 
 	@BeforeEach
 	public void setUp() {
 		super.setUp();
 		//	given
-		StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보);
-		StationTestFactory.지하철역_생성(StationAcceptanceTest.역삼역_정보);
+		강남역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보).as(StationResponse.class);
+		역삼역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.역삼역_정보).as(StationResponse.class);
+
+		신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선",
+			"bg-red-600", 강남역.getId(), 역삼역.getId(), 10);
+		이호선_정보 = LineTestFactory.지하철_노선_정보_정의("2호",
+			"bg-green-600", 강남역.getId(), 역삼역.getId(), 10);
 	}
 
 	@DisplayName("지하철 노선을 생성한다.")

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -12,6 +12,7 @@ import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.StationTestFactory;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,20 +21,21 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @DisplayName("지하철 노선 관련 기능")
-// @Transactional
 public class LineAcceptanceTest extends AcceptanceTest {
 
-	private static final String LINE_SERVICE_PATH = "/lines";
+	public static final String LINE_SERVICE_PATH = "/lines";
 
 	//	given
-	public static final Map<String, String> 신분당선_정보 = 지하철_노선_정보_정의("신분당선", "bg-red-600", 1L, 2L, 10);
-	public static final Map<String, String> 이호선_정보 = 지하철_노선_정보_정의("2호", "bg-green-600", 1L, 2L, 10);
+	public static final Map<String, String> 신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선",
+		"bg-red-600", 1L, 2L, 10);
+	public static final Map<String, String> 이호선_정보 = LineTestFactory.지하철_노선_정보_정의("2호",
+		"bg-green-600", 1L, 2L, 10);
 
 	@BeforeEach
 	public void setUpLineAcceptance() {
 		//	given
-		StationAcceptanceTest.지하철역_생성(StationAcceptanceTest.강남역_정보);
-		StationAcceptanceTest.지하철역_생성(StationAcceptanceTest.역삼역_정보);
+		StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보);
+		StationTestFactory.지하철역_생성(StationAcceptanceTest.역삼역_정보);
 	}
 
 	@DisplayName("지하철 노선을 생성한다.")
@@ -41,37 +43,37 @@ public class LineAcceptanceTest extends AcceptanceTest {
 	void createLine() {
 
 		// when
-		ExtractableResponse<Response> 신분당선_생성_결과 = 지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 신분당선_생성_결과 = LineTestFactory.지하철_노선_생성(신분당선_정보);
 
 		// then
-		정상_생성_확인(신분당선_생성_결과);
+		AcceptanceTestFactory.정상_생성_확인(신분당선_생성_결과);
 	}
 
 	@DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")
 	@Test
 	void createLine2() {
 		// given
-		지하철_노선_생성(신분당선_정보);
+		LineTestFactory.지하철_노선_생성(신분당선_정보);
 
 		// when
-		ExtractableResponse<Response> 신분당선_중복_생성_결과 = 지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 신분당선_중복_생성_결과 = LineTestFactory.지하철_노선_생성(신분당선_정보);
 
 		// then
-		예외_발생_확인(신분당선_중복_생성_결과);
+		AcceptanceTestFactory.예외_발생_확인(신분당선_중복_생성_결과);
 	}
 
 	@DisplayName("지하철 노선 목록을 조회한다.")
 	@Test
 	void getLines() {
 		// given
-		ExtractableResponse<Response> 신분당선_생성_되어있음 = 지하철_노선_생성(신분당선_정보);
-		ExtractableResponse<Response> 이호선_생성_되어있음 = 지하철_노선_생성(이호선_정보);
+		ExtractableResponse<Response> 신분당선_생성_되어있음 = LineTestFactory.지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 이호선_생성_되어있음 = LineTestFactory.지하철_노선_생성(이호선_정보);
 
 		// when
 		ExtractableResponse<Response> 지하철_노선_목록_결과 = 지하철_노선_조회(LINE_SERVICE_PATH);
 
 		// then
-		정상_처리_확인(지하철_노선_목록_결과);
+		AcceptanceTestFactory.정상_처리_확인(지하철_노선_목록_결과);
 		생성된_지하철_노선이_응답_목록에_포함되어있는_확인(Arrays.asList(신분당선_생성_되어있음, 이호선_생성_되어있음), 지하철_노선_목록_결과);
 	}
 
@@ -79,14 +81,14 @@ public class LineAcceptanceTest extends AcceptanceTest {
 	@Test
 	void getLine() {
 		// given
-		ExtractableResponse<Response> 신분당선_생성_되어있음 = 지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 신분당선_생성_되어있음 = LineTestFactory.지하철_노선_생성(신분당선_정보);
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
 		ExtractableResponse<Response> 신분당선_조회_결과 = AcceptanceTestFactory.get(신분당선_요청_경로);
 
 		//then
-		정상_처리_확인(신분당선_조회_결과);
+		AcceptanceTestFactory.정상_처리_확인(신분당선_조회_결과);
 		생성된_지하철_노선이_응답에_포함되어있는_확인(신분당선_조회_결과, 신분당선_요청_경로);
 	}
 
@@ -100,22 +102,23 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		ExtractableResponse<Response> 미등록_노선_조회_결과 = 지하철_노선_조회(미등록_노선_요청_경로);
 
 		// then
-		예외_발생_확인(미등록_노선_조회_결과);
+		AcceptanceTestFactory.예외_발생_확인(미등록_노선_조회_결과);
 	}
 
 	@DisplayName("지하철 노선을 수정한다.")
 	@Test
 	void updateLine() {
 		// given
-		ExtractableResponse<Response> 신분당선_생성_되어있음 = 지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 신분당선_생성_되어있음 = LineTestFactory.지하철_노선_생성(신분당선_정보);
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
-		Map<String, String> 신분당선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600", 1L, 2L, 10);
+		Map<String, String> 신분당선_수정정보 = LineTestFactory.지하철_노선_정보_정의("구분당", "bg-blue-600",
+			1L, 2L, 10);
 		ExtractableResponse<Response> 신분당선_수정_결과 = 지하철_노선_수정(신분당선_수정정보, 신분당선_요청_경로);
 
 		// then
-		정상_처리_확인(신분당선_수정_결과);
+		AcceptanceTestFactory.정상_처리_확인(신분당선_수정_결과);
 	}
 
 	private ExtractableResponse<Response> 지하철_노선_수정(Map<String, String> params, String createdUri) {
@@ -129,51 +132,30 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String 미등록_노선_요청_경로 = LINE_SERVICE_PATH + "/1";
 
 		// when
-		Map<String, String> 미등록_노선_수정정보 = 지하철_노선_정보_정의("구분당", "bg-blue-600", 1L, 2L, 10);
+		Map<String, String> 미등록_노선_수정정보 = LineTestFactory.지하철_노선_정보_정의("구분당", "bg-blue-600",
+			1L, 2L, 10);
 		ExtractableResponse<Response> 미등록_노선_수정_결과 = 지하철_노선_수정(미등록_노선_수정정보, 미등록_노선_요청_경로);
 
 		// then
-		예외_발생_확인(미등록_노선_수정_결과);
+		AcceptanceTestFactory.예외_발생_확인(미등록_노선_수정_결과);
 	}
 
 	@DisplayName("지하철 노선을 제거한다.")
 	@Test
 	void deleteLine() {
 		// given
-		ExtractableResponse<Response> 신분당선_생성_되어있음 = 지하철_노선_생성(신분당선_정보);
+		ExtractableResponse<Response> 신분당선_생성_되어있음 = LineTestFactory.지하철_노선_생성(신분당선_정보);
 		String 신분당선_요청_경로 = 신분당선_생성_되어있음.header("Location");
 
 		// when
 		ExtractableResponse<Response> 신분당선_삭제_결과 = 지하철_노선_삭제(신분당선_요청_경로);
 
 		// then
-		삭제_완료_확인(신분당선_삭제_결과);
-	}
-
-	private static Map<String, String> 지하철_노선_정보_정의(String name, String color, Long upStationId, Long downStationId,
-		int distance) {
-		return AcceptanceTestFactory.getLineInfo(name, color, upStationId, downStationId, distance);
-	}
-
-	private ExtractableResponse<Response> 지하철_노선_생성(Map<String, String> params) {
-		return AcceptanceTestFactory.post(params, LINE_SERVICE_PATH);
-	}
-
-	private void 정상_생성_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-		assertThat(response.header("Location")).isNotBlank();
-	}
-
-	private void 예외_발생_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+		AcceptanceTestFactory.삭제_완료_확인(신분당선_삭제_결과);
 	}
 
 	private ExtractableResponse<Response> 지하철_노선_조회(String path) {
 		return AcceptanceTestFactory.get(path);
-	}
-
-	private void 정상_처리_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 	}
 
 	private void 생성된_지하철_노선이_응답_목록에_포함되어있는_확인(List<ExtractableResponse<Response>> registeredLineResponses,
@@ -196,7 +178,4 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		return AcceptanceTestFactory.delete(createdUri);
 	}
 
-	private void 삭제_완료_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-	}
 }

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -39,10 +39,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		강남역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보).as(StationResponse.class);
 		역삼역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.역삼역_정보).as(StationResponse.class);
 
-		신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선",
-			"bg-red-600", 강남역.getId(), 역삼역.getId(), 10);
-		이호선_정보 = LineTestFactory.지하철_노선_정보_정의("2호",
-			"bg-green-600", 강남역.getId(), 역삼역.getId(), 10);
+		신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선", "bg-red-600", 강남역.getId(), 역삼역.getId(), 10);
+		이호선_정보 = LineTestFactory.지하철_노선_정보_정의("2호", "bg-green-600", 강남역.getId(), 역삼역.getId(), 10);
 	}
 
 	@DisplayName("지하철 노선을 생성한다.")
@@ -184,13 +182,13 @@ public class LineAcceptanceTest extends AcceptanceTest {
 		String createdId = resourceUrl.split("/")[2];
 
 		LineResponse lineResponse = response.as(LineResponse.class);
-		assertLineBaseCheck(lineResponse,createdId,requestLine);
+		assertLineBaseCheck(lineResponse, createdId, requestLine);
 
 		List<Station> stations = lineResponse.getStations();
-		assertStations(stations,requestStations);
+		assertStations(stations, requestStations);
 	}
 
-	private void assertLineBaseCheck(LineResponse lineResponse,String createdId, Map<String, String> requestLine) {
+	private void assertLineBaseCheck(LineResponse lineResponse, String createdId, Map<String, String> requestLine) {
 		assertThat(lineResponse.getId()).isEqualTo(Long.parseLong(createdId));
 		assertThat(lineResponse.getColor()).isEqualTo(requestLine.get("color"));
 		assertThat(lineResponse.getName()).isEqualTo(requestLine.get("name"));

--- a/src/test/java/nextstep/subway/line/LineTestFactory.java
+++ b/src/test/java/nextstep/subway/line/LineTestFactory.java
@@ -1,0 +1,19 @@
+package nextstep.subway.line;
+
+import java.util.Map;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.testFactory.AcceptanceTestFactory;
+
+public class LineTestFactory {
+
+	public static Map<String, String> 지하철_노선_정보_정의(String name, String color, Long upStationId, Long downStationId,
+		int distance) {
+		return AcceptanceTestFactory.getLineInfo(name, color, upStationId, downStationId, distance);
+	}
+
+	public static ExtractableResponse<Response> 지하철_노선_생성(Map<String, String> params) {
+		return AcceptanceTestFactory.post(params, LineAcceptanceTest.LINE_SERVICE_PATH);
+	}
+}

--- a/src/test/java/nextstep/subway/line/LineTestFactory.java
+++ b/src/test/java/nextstep/subway/line/LineTestFactory.java
@@ -1,5 +1,6 @@
 package nextstep.subway.line;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import io.restassured.response.ExtractableResponse;
@@ -8,12 +9,18 @@ import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 public class LineTestFactory {
 
-	public static Map<String, String> 지하철_노선_정보_정의(String name, String color, Long upStationId, Long downStationId,
-		int distance) {
-		return AcceptanceTestFactory.getLineInfo(name, color, upStationId, downStationId, distance);
-	}
-
 	public static ExtractableResponse<Response> 지하철_노선_생성(Map<String, String> params) {
 		return AcceptanceTestFactory.post(params, LineAcceptanceTest.LINE_SERVICE_PATH);
+	}
+
+	public static Map<String, String> 지하철_노선_정보_정의(String name, String color, Long upStationId, Long downStationId,
+		int distance) {
+		Map<String, String> params = new HashMap<>();
+		params.put("name", name);
+		params.put("color", color);
+		params.put("upStationId", String.valueOf(upStationId));
+		params.put("downStationId", String.valueOf(downStationId));
+		params.put("distance", String.valueOf(distance));
+		return params;
 	}
 }

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -46,10 +46,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 	@DisplayName("노선 중간에 구간을 등록한다.(상행역과 맞닿음)")
 	@Test
 	void addSection() {
-		// when
+		// given
 		Map<String, String> 성복역_정보 = StationTestFactory.지하철역_이름_정의("성복역");
 		StationResponse 성복역 = StationTestFactory.지하철역_생성(성복역_정보).as(StationResponse.class);
 
+		// when
 		Map<String, String> 강남_성복_구간_정보 = 구간_정보_정의(강남역.getId(), 성복역.getId(), 5);
 		ExtractableResponse<Response> 강남_성복_구간_등록_결과 = 지하철_노선에_구간_등록_요청(강남_성복_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
@@ -62,10 +63,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 	@DisplayName("노선 중간에 구간을 등록한다.(하행역과 맞닿음)")
 	@Test
 	void addSection2() {
-		// when
+		// given
 		Map<String, String> 성복역_정보 = StationTestFactory.지하철역_이름_정의("성복역");
 		StationResponse 성복역 = StationTestFactory.지하철역_생성(성복역_정보).as(StationResponse.class);
 
+		// when
 		Map<String, String> 성복_광교_구간_정보 = 구간_정보_정의(성복역.getId(), 광교역.getId(), 7);
 		ExtractableResponse<Response> 성복_광교_구간_등록_결과 = 지하철_노선에_구간_등록_요청(성복_광교_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
@@ -78,10 +80,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 	@DisplayName("상행 종점 앞에 구간 추가")
 	@Test
 	void addSection3() {
-		// when
+		// given
 		Map<String, String> 신논현_정보 = StationTestFactory.지하철역_이름_정의("신논현");
 		StationResponse 신논현 = StationTestFactory.지하철역_생성(신논현_정보).as(StationResponse.class);
 
+		// when
 		Map<String, String> 신논현_강남_구간_정보 = 구간_정보_정의(신논현.getId(), 강남역.getId(), 12);
 		ExtractableResponse<Response> 신논현_강남_구간_등록_결과 = 지하철_노선에_구간_등록_요청(신논현_강남_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
@@ -94,10 +97,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 	@DisplayName("하행 종점 뒤에 구간 추가")
 	@Test
 	void addSection4() {
-		// when
+		// given
 		Map<String, String> 호매실역_정보 = StationTestFactory.지하철역_이름_정의("호매실");
 		StationResponse 호매실역 = StationTestFactory.지하철역_생성(호매실역_정보).as(StationResponse.class);
 
+		// when
 		Map<String, String> 광교_호매실_구간_정보 = 구간_정보_정의(광교역.getId(), 호매실역.getId(), 15);
 		ExtractableResponse<Response> 광교_호매실_구간_등록_결과 = 지하철_노선에_구간_등록_요청(광교_호매실_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
@@ -110,10 +114,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 	@DisplayName("기존 역 사이 길이보다 크거나 같으면 등록할 수 없음")
 	@Test
 	void addSection_exception1() {
-		// when
+		// given
 		Map<String, String> 성복역_정보 = StationTestFactory.지하철역_이름_정의("성복역");
 		StationResponse 성복역 = StationTestFactory.지하철역_생성(성복역_정보).as(StationResponse.class);
 
+		// when
 		Map<String, String> 강남_성복_구간_정보 = 구간_정보_정의(강남역.getId(), 성복역.getId(), 10);
 		ExtractableResponse<Response> 강남_성복_구간_등록_결과 = 지하철_노선에_구간_등록_요청(강남_성복_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
@@ -132,11 +137,11 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		지하철_노선에_구간_등록_요청(강남_성복_구간_정보, getLineSectionServicePath(신분당선.getId()));
 
 		// when
-		Map<String, String> 강남_광교_구간_정보 = 구간_정보_정의(강남역.getId(), 광교역.getId(), 10);
-		ExtractableResponse<Response> 강남_광교_구간_등록_결과 = 지하철_노선에_구간_등록_요청(강남_광교_구간_정보,
+		ExtractableResponse<Response> 강남_성복_구간_등록_결과 = 지하철_노선에_구간_등록_요청(강남_성복_구간_정보,
 			getLineSectionServicePath(신분당선.getId()));
+
 		// then
-		AcceptanceTestFactory.예외_발생_확인(강남_광교_구간_등록_결과);
+		AcceptanceTestFactory.예외_발생_확인(강남_성복_구간_등록_결과);
 	}
 
 	@DisplayName("상행역_하행역_모두_기존에_없는_경우")
@@ -150,7 +155,8 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// when
 		Map<String, String> 성복_수지구청_구간_정보 = 구간_정보_정의(성복역.getId(), 수지구청역.getId(), 7);
-		ExtractableResponse<Response> 성복_수지구청_구간_등록_결과 = 지하철_노선에_구간_등록_요청(성복_수지구청_구간_정보, getLineSectionServicePath(신분당선.getId()));
+		ExtractableResponse<Response> 성복_수지구청_구간_등록_결과 = 지하철_노선에_구간_등록_요청(성복_수지구청_구간_정보,
+			getLineSectionServicePath(신분당선.getId()));
 
 		// then
 		AcceptanceTestFactory.예외_발생_확인(성복_수지구청_구간_등록_결과);

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -1,0 +1,72 @@
+package nextstep.subway.line;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.StationTestFactory;
+import nextstep.subway.station.dto.StationResponse;
+import nextstep.subway.testFactory.AcceptanceTestFactory;
+
+@DisplayName("구간 등록 관련 기능")
+public class SectionAcceptanceTest extends AcceptanceTest {
+
+	private StationResponse 강남역;
+	private StationResponse 광교역;
+	private LineResponse 신분당선;
+
+	public static final String SECTION_SERVICE_PATH = "/sections";
+
+	@BeforeEach
+	public void setUp() {
+		super.setUp();
+
+		// given
+		강남역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.강남역_정보).as(StationResponse.class);
+		광교역 = StationTestFactory.지하철역_생성(StationAcceptanceTest.광교역_정보).as(StationResponse.class);
+
+		Map<String, String> 신분당선_정보 = LineTestFactory.지하철_노선_정보_정의("신분당선", "bg-red-600",
+			강남역.getId(), 광교역.getId(), 10);
+		신분당선 = LineTestFactory.지하철_노선_생성(신분당선_정보).as(LineResponse.class);
+	}
+
+	@DisplayName("노선에 구간을 등록한다.")
+	@Test
+	void addSection() {
+		// when
+		Map<String, String> 성복역_정보 = StationTestFactory.지하철역_이름_정의("성복역");
+		StationResponse 성복역 = StationTestFactory.지하철역_생성(성복역_정보).as(StationResponse.class);
+
+		Map<String, String> 강남_성복_구간_정보 = 구간_정보_정의(강남역.getId(), 성복역.getId(), 5);
+		ExtractableResponse<Response> 강남_성복_구간_등록_결과 = 지하철_노선에_구간_등록_요청(강남_성복_구간_정보,
+			getLineSectionServicePath(신분당선.getId()));
+
+		// then
+		AcceptanceTestFactory.정상_생성_확인(강남_성복_구간_등록_결과);
+	}
+
+	private ExtractableResponse<Response> 지하철_노선에_구간_등록_요청(Map<String, String> params, String path) {
+		return AcceptanceTestFactory.post(params, path);
+	}
+
+	private Map<String, String> 구간_정보_정의(Long upStationId, Long downStationId, int distance) {
+		Map<String, String> params = new HashMap<>();
+		params.put("upStationId", String.valueOf(upStationId));
+		params.put("downStationId", String.valueOf(downStationId));
+		params.put("distance", String.valueOf(distance));
+		return params;
+	}
+
+	private String getLineSectionServicePath(Long lineId) {
+		return String.join("", LineAcceptanceTest.LINE_SERVICE_PATH, "/", String.valueOf(lineId),
+			SECTION_SERVICE_PATH);
+	}
+}

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -38,7 +38,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 		신분당선 = LineTestFactory.지하철_노선_생성(신분당선_정보).as(LineResponse.class);
 	}
 
-	@DisplayName("노선에 구간을 등록한다.")
+	@DisplayName("노선 중간에 구간을 등록한다.(상행역과 맞닿음)")
 	@Test
 	void addSection() {
 		// when
@@ -51,6 +51,51 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
 		// then
 		AcceptanceTestFactory.정상_생성_확인(강남_성복_구간_등록_결과);
+	}
+
+	@DisplayName("노선 중간에 구간을 등록한다.(하행역과 맞닿음)")
+	@Test
+	void addSection2() {
+		// when
+		Map<String, String> 성복역_정보 = StationTestFactory.지하철역_이름_정의("성복역");
+		StationResponse 성복역 = StationTestFactory.지하철역_생성(성복역_정보).as(StationResponse.class);
+
+		Map<String, String> 성복_광교_구간_정보 = 구간_정보_정의(성복역.getId(),광교역.getId(), 7);
+		ExtractableResponse<Response> 성복_광교_구간_등록_결과 = 지하철_노선에_구간_등록_요청(성복_광교_구간_정보,
+			getLineSectionServicePath(신분당선.getId()));
+
+		// then
+		AcceptanceTestFactory.정상_생성_확인(성복_광교_구간_등록_결과);
+	}
+
+	@DisplayName("상행 종점 앞에 구간 추가")
+	@Test
+	void addSection3() {
+		// when
+		Map<String, String> 신논현_정보 = StationTestFactory.지하철역_이름_정의("신논현");
+		StationResponse 신논현 = StationTestFactory.지하철역_생성(신논현_정보).as(StationResponse.class);
+
+		Map<String, String> 신논현_강남_구간_정보 = 구간_정보_정의(신논현.getId(),강남역.getId(), 12);
+		ExtractableResponse<Response> 신논현_강남_구간_등록_결과 = 지하철_노선에_구간_등록_요청(신논현_강남_구간_정보,
+			getLineSectionServicePath(신분당선.getId()));
+
+		// then
+		AcceptanceTestFactory.정상_생성_확인(신논현_강남_구간_등록_결과);
+	}
+
+	@DisplayName("하행 종점 뒤에 구간 추가")
+	@Test
+	void addSection4() {
+		// when
+		Map<String, String> 호매실_정보 = StationTestFactory.지하철역_이름_정의("호매실");
+		StationResponse 호매실 = StationTestFactory.지하철역_생성(호매실_정보).as(StationResponse.class);
+
+		Map<String, String> 광교_호매실_구간_정보 = 구간_정보_정의(광교역.getId(),호매실.getId(), 15);
+		ExtractableResponse<Response> 광교_호매실_구간_등록_결과 = 지하철_노선에_구간_등록_요청(광교_호매실_구간_정보,
+			getLineSectionServicePath(신분당선.getId()));
+
+		// then
+		AcceptanceTestFactory.정상_생성_확인(광교_호매실_구간_등록_결과);
 	}
 
 	private ExtractableResponse<Response> 지하철_노선에_구간_등록_요청(Map<String, String> params, String path) {

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -3,7 +3,7 @@ package nextstep.subway.station;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.dto.StationResponse;
 import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 import org.junit.jupiter.api.DisplayName;
@@ -79,7 +79,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
 	}
 
 	private void 생성된_지하철역이_응답에_포함되어있는_확인(ExtractableResponse<Response> response, String createdUri) {
-		assertThat(response.jsonPath().getObject(".", LineResponse.class).getId()).isEqualTo(
+		assertThat(response.jsonPath().getObject(".", StationResponse.class).getId()).isEqualTo(
 			Long.parseLong(createdUri.split("/")[2]));
 	}
 
@@ -104,13 +104,13 @@ public class StationAcceptanceTest extends AcceptanceTest {
 
 	private void 생성된_지하철역이_응답_목록에_포함되어있는_확인(List<ExtractableResponse<Response>> registeredStationResponses,
 		ExtractableResponse<Response> response) {
-		List<Long> expectedLineIds = registeredStationResponses.stream()
+		List<Long> expectedStationIds = registeredStationResponses.stream()
 			.map(it -> Long.parseLong(it.header("Location").split("/")[2]))
 			.collect(Collectors.toList());
-		List<Long> resultLineIds = response.jsonPath().getList(".", LineResponse.class).stream()
+		List<Long> resultStationIds = response.jsonPath().getList(".", StationResponse.class).stream()
 			.map(it -> it.getId())
 			.collect(Collectors.toList());
-		assertThat(resultLineIds).containsAll(expectedLineIds);
+		assertThat(resultStationIds).containsAll(expectedStationIds);
 	}
 
 

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -24,6 +24,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
 	//	given
 	public static final Map<String, String> 강남역_정보 = StationTestFactory.지하철역_이름_정의("강남역");
 	public static final Map<String, String> 역삼역_정보 = StationTestFactory.지하철역_이름_정의("역삼역");
+	public static final Map<String, String> 광교역_정보 = StationTestFactory.지하철역_이름_정의("광교역");
 
 	@DisplayName("지하철역을 생성한다.")
 	@Test

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -8,7 +8,6 @@ import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,47 +19,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
 
-	private static final String STATION_SERVICE_PATH = "/stations";
+	public static final String STATION_SERVICE_PATH = "/stations";
 
 	//	given
-	public static final Map<String, String> 강남역_정보 = 지하철역_이름_정의("강남역");
-	public static final Map<String, String> 역삼역_정보 = 지하철역_이름_정의("역삼역");
+	public static final Map<String, String> 강남역_정보 = StationTestFactory.지하철역_이름_정의("강남역");
+	public static final Map<String, String> 역삼역_정보 = StationTestFactory.지하철역_이름_정의("역삼역");
 
 	@DisplayName("지하철역을 생성한다.")
 	@Test
 	void createStation() {
 		// when
-		ExtractableResponse<Response> 강남역_생성_결과 = 지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 강남역_생성_결과 = StationTestFactory.지하철역_생성(강남역_정보);
 
 		// then
-		정상_생성_확인(강남역_생성_결과);
+		AcceptanceTestFactory.정상_생성_확인(강남역_생성_결과);
 	}
 
 	@DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
 	@Test
 	void createStationWithDuplicateName() {
 		// given
-		지하철역_생성(강남역_정보);
+		StationTestFactory.지하철역_생성(강남역_정보);
 
 		// when
-		ExtractableResponse<Response> 강남역_중복_생성_결과 = 지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 강남역_중복_생성_결과 = StationTestFactory.지하철역_생성(강남역_정보);
 
 		// then
-		예외_발생_확인(강남역_중복_생성_결과);
+		AcceptanceTestFactory.예외_발생_확인(강남역_중복_생성_결과);
 	}
 
 	@DisplayName("지하철역 목록을 조회한다.")
 	@Test
 	void getStations() {
 		// given
-		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
-		ExtractableResponse<Response> 역삼역_생성_되어있음 = 지하철역_생성(역삼역_정보);
+		ExtractableResponse<Response> 강남역_생성_되어있음 = StationTestFactory.지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 역삼역_생성_되어있음 = StationTestFactory.지하철역_생성(역삼역_정보);
 
 		// when
 		ExtractableResponse<Response> 지하철역_목록_결과 = 지하철역_조회(STATION_SERVICE_PATH);
 
 		// then
-		정상_처리_확인(지하철역_목록_결과);
+		AcceptanceTestFactory.정상_처리_확인(지하철역_목록_결과);
 		생성된_지하철역이_응답_목록에_포함되어있는_확인(Arrays.asList(강남역_생성_되어있음, 역삼역_생성_되어있음), 지하철역_목록_결과);
 	}
 
@@ -68,13 +67,14 @@ public class StationAcceptanceTest extends AcceptanceTest {
 	@Test
 	void getStation() {
 		// given
-		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 강남역_생성_되어있음 = StationTestFactory.지하철역_생성(강남역_정보);
 		String 강남역_요청_경로 = 강남역_생성_되어있음.header("Location");
+
 		// when
 		ExtractableResponse<Response> 강남역_조회_결과 = 지하철역_조회(강남역_요청_경로);
 
 		// then
-		정상_처리_확인(강남역_조회_결과);
+		AcceptanceTestFactory.정상_처리_확인(강남역_조회_결과);
 		생성된_지하철역이_응답에_포함되어있는_확인(강남역_조회_결과, 강남역_요청_경로);
 	}
 
@@ -87,32 +87,16 @@ public class StationAcceptanceTest extends AcceptanceTest {
 	@Test
 	void deleteStation() {
 		// given
-		ExtractableResponse<Response> 강남역_생성_되어있음 = 지하철역_생성(강남역_정보);
+		ExtractableResponse<Response> 강남역_생성_되어있음 = StationTestFactory.지하철역_생성(강남역_정보);
 		String 강남역_요청_경로 = 강남역_생성_되어있음.header("Location");
 
 		// when
 		ExtractableResponse<Response> 강남역_삭제_결과 = 지하철역_삭제(강남역_요청_경로);
 
 		// then
-		삭제_완료_확인(강남역_삭제_결과);
+		AcceptanceTestFactory.삭제_완료_확인(강남역_삭제_결과);
 	}
 
-	public static Map<String, String> 지하철역_이름_정의(String name) {
-		return AcceptanceTestFactory.getNameContent(name);
-	}
-
-	public static ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
-		return AcceptanceTestFactory.post(params, STATION_SERVICE_PATH);
-	}
-
-	private void 정상_생성_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-		assertThat(response.header("Location")).isNotBlank();
-	}
-
-	private void 예외_발생_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-	}
 
 	private ExtractableResponse<Response> 지하철역_조회(String path) {
 		return AcceptanceTestFactory.get(path);
@@ -129,15 +113,8 @@ public class StationAcceptanceTest extends AcceptanceTest {
 		assertThat(resultLineIds).containsAll(expectedLineIds);
 	}
 
-	private void 정상_처리_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-	}
 
 	private ExtractableResponse<Response> 지하철역_삭제(String createdUri) {
 		return AcceptanceTestFactory.delete(createdUri);
-	}
-
-	private void 삭제_완료_확인(ExtractableResponse<Response> response) {
-		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
 }

--- a/src/test/java/nextstep/subway/station/StationTestFactory.java
+++ b/src/test/java/nextstep/subway/station/StationTestFactory.java
@@ -1,5 +1,6 @@
 package nextstep.subway.station;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import io.restassured.response.ExtractableResponse;
@@ -8,11 +9,13 @@ import nextstep.subway.testFactory.AcceptanceTestFactory;
 
 public class StationTestFactory {
 
-	public static Map<String, String> 지하철역_이름_정의(String name) {
-		return AcceptanceTestFactory.getNameContent(name);
-	}
-
 	public static ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
 		return AcceptanceTestFactory.post(params, StationAcceptanceTest.STATION_SERVICE_PATH);
+	}
+
+	public static Map<String, String> 지하철역_이름_정의(String name) {
+		Map<String, String> params = new HashMap<>();
+		params.put("name", name);
+		return params;
 	}
 }

--- a/src/test/java/nextstep/subway/station/StationTestFactory.java
+++ b/src/test/java/nextstep/subway/station/StationTestFactory.java
@@ -1,0 +1,18 @@
+package nextstep.subway.station;
+
+import java.util.Map;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.testFactory.AcceptanceTestFactory;
+
+public class StationTestFactory {
+
+	public static Map<String, String> 지하철역_이름_정의(String name) {
+		return AcceptanceTestFactory.getNameContent(name);
+	}
+
+	public static ExtractableResponse<Response> 지하철역_생성(Map<String, String> params) {
+		return AcceptanceTestFactory.post(params, StationAcceptanceTest.STATION_SERVICE_PATH);
+	}
+}

--- a/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
+++ b/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
@@ -1,8 +1,11 @@
 package nextstep.subway.testFactory;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import io.restassured.RestAssured;
@@ -16,6 +19,23 @@ public class AcceptanceTestFactory {
 		Map<String, String> params = new HashMap<>();
 		params.put("name", name);
 		return params;
+	}
+
+	public static void 정상_생성_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+		assertThat(response.header("Location")).isNotBlank();
+	}
+
+	public static void 예외_발생_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	public static void 정상_처리_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	public static void 삭제_완료_확인(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 	}
 
 	public static ExtractableResponse<Response> post(Map<String, String> params, String path) {

--- a/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
+++ b/src/test/java/nextstep/subway/testFactory/AcceptanceTestFactory.java
@@ -15,11 +15,7 @@ import io.restassured.specification.RequestSpecification;
 
 public class AcceptanceTestFactory {
 
-	public static Map<String, String> getNameContent(String name) {
-		Map<String, String> params = new HashMap<>();
-		params.put("name", name);
-		return params;
-	}
+
 
 	public static void 정상_생성_확인(ExtractableResponse<Response> response) {
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -71,17 +67,6 @@ public class AcceptanceTestFactory {
 		return response
 			.then().log().all()
 			.extract();
-	}
-
-	public static Map<String, String> getLineInfo(String name, String color, Long upStationId, Long downStationId,
-		int distance) {
-		Map<String, String> params = new HashMap<>();
-		params.put("name", name);
-		params.put("color", color);
-		params.put("upStationId", String.valueOf(upStationId));
-		params.put("downStationId", String.valueOf(downStationId));
-		params.put("distance", String.valueOf(distance));
-		return params;
 	}
 }
 


### PR DESCRIPTION
안녕하세요 지호님!🙂
지난번 리뷰도 좋은 조언들 많이 남겨주셔서 감사했습니다. 

구간 추가 기능을 1)상행종점 위 추가 경우 2)하행종점 아래 추가 경우 3)노선 구간 내, 상행역에 닿는 경우 4) 노선 구간 내, 하행역에 닿는 경우로 나누어 구현하였습니다.
3)4)의 경우는 처음에는 for문을 써서 한번에 로직을 태웠었는데요, depth를 2로(if를 안 쓰려니) 하지 않으려니 방법이 떠오르지 않아서 각각을 따로 스트림 태워 처리하는 방식으로 변경하였습니다. 
이렇게 나눠서 처리하니 코드는 훨씬 직관적이긴 한데 List<Section>을 두번 순회하게되어 고민입니다.
O(n) 만큼의 순회 시간이니 두번 순회하는 비용은 무시하여도 될까요?

벌써 한주가 가고 금요일이네요! 
오늘도 좋은 하루 되세요😊