### PR TITLE
4단계 - 구간 제거 기능

### DIFF
--- a/src/main/java/nextstep/subway/WebControllerAdvice.java
+++ b/src/main/java/nextstep/subway/WebControllerAdvice.java
@@ -14,6 +14,13 @@ import nextstep.subway.exception.NotFoundException;
 public class WebControllerAdvice {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public void handleException(Exception exception) {
+        log.error(exception.getMessage());
+        // 이 부분에서 모니터링 시스템에 에러 전송
+    }
+
     @ExceptionHandler(BadRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public void handleBadRequest(BadRequestException exception) {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -64,6 +64,12 @@ public class LineService {
         line.addSection(additionalSection);
     }
 
+    public void deleteSection(final Long stationId, final Long id) {
+        final Line line = getLineById(id);
+        final Station targetStation = getStationById(stationId);
+        line.deleteSection(targetStation);
+    }
+
     private void validateDuplicatedName(final LineRequest request) {
         final boolean duplicated = lineRepository.findByName(request.getName()).isPresent();
         if (duplicated) {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -43,6 +43,10 @@ public class Line extends BaseEntity {
         sections.addSection(section);
     }
 
+    public void deleteSection(final Station targetStation) {
+        sections.deleteSection(targetStation);
+    }
+
     public List<Station> computeSortedStations() {
         return sections.computeSortedStations();
     }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -45,6 +45,9 @@ public class Section extends BaseEntity {
     }
 
     void divideBy(Section section) {
+        if (!isOverlapped(section)) {
+            throw new IllegalArgumentException("section must be overlapped to divide");
+        }
         if (section.getDistance() >= distance) {
             throw new BadRequestException("추가되는 구간의 길이가 기존 역 사이의 길이보다 크거나 같을 수 없습니다.");
         }
@@ -58,6 +61,9 @@ public class Section extends BaseEntity {
     }
 
     void connectWith(final Section section) {
+        if (!isNextSection(section) && !section.isNextSection(this)) {
+            throw new IllegalArgumentException("section cannot be connected");
+        }
         if (isNextSection(section)) {
             upStation = section.getUpStation();
         }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -57,6 +57,16 @@ public class Section extends BaseEntity {
         distance = distance - section.getDistance();
     }
 
+    void connectWith(final Section section) {
+        if (isNextSection(section)) {
+            upStation = section.getUpStation();
+        }
+        if (section.isNextSection(this)) {
+            downStation = section.getDownStation();
+        }
+        distance = distance + section.getDistance();
+    }
+
     List<Station> getStations() {
         return Arrays.asList(upStation, downStation);
     }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -38,14 +38,14 @@ public class Sections {
         final Set<Station> allStations = extractAllStations();
         final List<Station> sectionStations = section.getStations();
 
-        final long matchCount = sectionStations.stream()
+        final Set<Station> matchedStations = sectionStations.stream()
             .filter(allStations::contains)
-            .count();
+            .collect(Collectors.toSet());
 
-        if (matchCount == 0) {
+        if (matchedStations.isEmpty()) {
             throw new BadRequestException("추가되는 구간은 기존의 구간과 연결 가능하여야 합니다.");
         }
-        if (matchCount == 2) {
+        if (matchedStations.containsAll(sectionStations)) {
             throw new BadRequestException("상행역과 하행역이 이미 노선에 모두 등록되어 있습니다.");
         }
     }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import nextstep.subway.line.application.LineService;
@@ -63,5 +64,11 @@ public class LineController {
         @RequestBody final SectionRequest sectionRequest, @PathVariable final Long id) {
         lineService.addSection(sectionRequest, id);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{id}/sections")
+    public ResponseEntity<Void> deleteSection(@RequestParam Long stationId, @PathVariable final Long id) {
+        lineService.deleteSection(stationId, id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -1,8 +1,12 @@
 package nextstep.subway.station.domain;
 
-import nextstep.subway.common.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
-import javax.persistence.*;
+import nextstep.subway.common.BaseEntity;
 
 @Entity
 public class Station extends BaseEntity {
@@ -26,5 +30,13 @@ public class Station extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String toString() {
+        return "Station{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ handlebars.enabled=true
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/test/java/nextstep/subway/line/domain/SectionTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.line.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -83,5 +84,36 @@ public class SectionTest {
         assertThat(section1.getUpStation()).isEqualTo(송내역);
         assertThat(section1.getDownStation()).isEqualTo(신도림역);
         assertThat(section1.getDistance()).isEqualTo(10);
+    }
+
+    @DisplayName("겹치지 않은 섹션을 통해 divideBy 메서드를 사용하려 할 때 예외 발생")
+    @Test
+    void divideByNotOverlappedSection() {
+        // given
+        final Station 송내역 = stationRepository.save(new Station("송내역"));
+        final Station 부천역 = stationRepository.save(new Station("부천역"));
+        final Station 신도림역 = stationRepository.save(new Station("신도림역"));
+        final Section section1 = new Section(송내역, 부천역, 1);
+        final Section section2 = new Section(부천역, 신도림역, 9);
+
+        // when, then
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> section1.divideBy(section2));
+    }
+
+    @DisplayName("연결할 수 없는 섹션과 connectWith 메서드를 사용하려고 할 때 예외 발생")
+    @Test
+    void connectWithSeparatedSection() {
+        // given
+        final Station 송내역 = stationRepository.save(new Station("송내역"));
+        final Station 부천역 = stationRepository.save(new Station("부천역"));
+        final Station 신도림역 = stationRepository.save(new Station("신도림역"));
+        final Station 용산역 = stationRepository.save(new Station("용산역"));
+        final Section section1 = new Section(송내역, 부천역, 1);
+        final Section section2 = new Section(신도림역, 용산역, 9);
+
+        // when, then
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> section1.connectWith(section2));
     }
 }

--- a/src/test/java/nextstep/subway/line/domain/SectionTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionTest.java
@@ -66,4 +66,22 @@ public class SectionTest {
         assertThat(section1.getDownStation()).isEqualTo(부천역);
         assertThat(section1.getDistance()).isEqualTo(1);
     }
+
+    @Test
+    void connectWith() {
+        // given
+        final Station 송내역 = stationRepository.save(new Station("송내역"));
+        final Station 부천역 = stationRepository.save(new Station("부천역"));
+        final Station 신도림역 = stationRepository.save(new Station("신도림역"));
+        final Section section1 = new Section(송내역, 부천역, 1);
+        final Section section2 = new Section(부천역, 신도림역, 9);
+
+        // when
+        section1.connectWith(section2);
+
+        // then
+        assertThat(section1.getUpStation()).isEqualTo(송내역);
+        assertThat(section1.getDownStation()).isEqualTo(신도림역);
+        assertThat(section1.getDistance()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
Section 객체 내의 divideBy(), connectWith() 메서드 맨 앞을 보시면 IllegalArgumentException을 발생시킵니다.
그리고 WebControllerAdvice에서 모든 Exception을 받아서 500을 발생시키고 있습니다.

IllegalArgumentException를 발생시키는 두 케이스는 클라이언트로부터 잘못된 요청이 들어올 때가 아니라, 개발자가 의도에 맞지 않게 메서드를 사용한 것이라고 판단했습니다. 물론 개발자가 어떻게 사용해도 상관없도록 메서드를 만드는 게 좋을 수 있겠지만 이 부분에서는 그러지 못했네요.

보통 이럴 때 실무에서 어떻게 하시는 지 궁금합니다. 저 같은 경우에는 지금과 같이 그냥 500을 내버리는데요. 보통 500이 발생할 때만 모니터링 시스템에 예외에 대한 정보가 전송되고, 개발자에게 실시간으로 알람이 오기 때문입니다.

잘 부탁드립니다 😃 