### PR TITLE
Step2 : 인수테스트 2단계 구현 

### DIFF
--- a/src/main/java/nextstep/subway/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/subway/common/exception/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
             e.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(InvalidValueException.class)
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
             e.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 }
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -22,21 +22,20 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
-        checkName(request.getName());
+        checkExistsByName(request.getName());
         Line persistLine = lineRepository.save(request.toLine());
         return LineResponse.of(persistLine);
     }
 
-    private void checkName(String name) {
-        Line existingLine = lineRepository.findByName(name);
-        if (existingLine != null) {
+    private void checkExistsByName(String name) {
+        if (lineRepository.existsByName(name)) {
             throw new NameDuplicateException("이미 존재하는 이름입니다. : " + name);
         }
     }
 
     public LineResponse update(LineRequest request, Long id) {
         Line line = line(id);
-        checkName(request.getName());
+        checkExistsByName(request.getName());
         line.update(request.toLine());
         return LineResponse.of(line);
     }
@@ -44,7 +43,7 @@ public class LineService {
     public List<LineResponse> getLines() {
         List<Line> lines = lineRepository.findAll();
         return lines.stream()
-            .map(line -> LineResponse.of(line))
+            .map(LineResponse::of)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
-import nextstep.subway.line.domain.SectionRepository;
-import nextstep.subway.line.domain.Sections;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.line.exception.LineNotFoundException;
@@ -24,8 +22,10 @@ public class LineService {
 
     private StationRepository stationRepository;
 
-    public LineService(LineRepository lineRepository) {
+    public LineService(LineRepository lineRepository,
+        StationRepository stationRepository) {
         this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
     }
 
     public LineResponse saveLine(LineRequest request) {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -32,13 +32,21 @@ public class Line extends BaseEntity {
 
     public static Line of(String name, String color, Station upStation, Station downStation, int distance) {
         Line line = new Line(name, color);
-        line.sections.addSections(line, upStation, downStation, distance);
+        line.addSections(upStation, downStation, distance);
         return line;
+    }
+
+    public void addSections(Station upStation, Station downStation, int distance) {
+        this.sections.addSections(Section.of(this, upStation, downStation, distance));
     }
 
     public void update(Line line) {
         this.name = line.getName();
         this.color = line.getColor();
+    }
+
+    public List<Station> stations() {
+        return this.sections.stations();
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -10,8 +10,11 @@ public class Line extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(unique = true)
+
+    @Column(unique = true, nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String color;
 
     public Line() {

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -1,8 +1,10 @@
 package nextstep.subway.line.domain;
 
+import java.util.List;
 import nextstep.subway.common.BaseEntity;
 
 import javax.persistence.*;
+import nextstep.subway.station.domain.Station;
 
 @Entity
 public class Line extends BaseEntity {
@@ -17,12 +19,21 @@ public class Line extends BaseEntity {
     @Column(nullable = false)
     private String color;
 
+    @Embedded
+    private Sections sections = new Sections();
+
     public Line() {
     }
 
     public Line(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public static Line of(String name, String color, Station upStation, Station downStation, int distance) {
+        Line line = new Line(name, color);
+        line.sections.addSections(line, upStation, downStation, distance);
+        return line;
     }
 
     public void update(Line line) {

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
 
-    Line findByName(String name);
+    boolean existsByName(String name);
 
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -1,30 +1,48 @@
 package nextstep.subway.line.domain;
 
 import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import nextstep.subway.station.domain.Station;
 
+@Entity
 public class Section {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "line_id")
     private Line line;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "up_station_id")
     private Station upStation;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "down_station_id")
     private Station downStation;
 
     private int distance;
+
+    public Section() {
+    }
 
     public Section(Line line, Station upStation, Station downStation, int distance) {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
+    }
+
+    public static Section of(Line line, Station upStation, Station downStation, int distance) {
+        return new Section(line, upStation, downStation, distance);
     }
 
     public boolean isUp(Section section) {

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -1,0 +1,69 @@
+package nextstep.subway.line.domain;
+
+import java.util.Objects;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import nextstep.subway.station.domain.Station;
+
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Line line;
+
+    private Station upStation;
+
+    private Station downStation;
+
+    private int distance;
+
+    public Section(Line line, Station upStation, Station downStation, int distance) {
+        this.line = line;
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Line getLine() {
+        return line;
+    }
+
+    public Station getUpStation() {
+        return upStation;
+    }
+
+    public Station getDownStation() {
+        return downStation;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Section section = (Section) o;
+        return distance == section.distance && Objects.equals(id, section.id)
+            && Objects.equals(line, section.line) && Objects
+            .equals(upStation, section.upStation) && Objects
+            .equals(downStation, section.downStation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, line, upStation, downStation, distance);
+    }
+}

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -27,6 +27,14 @@ public class Section {
         this.distance = distance;
     }
 
+    public boolean isUp(Section section) {
+        return this.downStation.equals(section.getUpStation());
+    }
+
+    public boolean isDown(Section section) {
+        return this.upStation.equals(section.getDownStation());
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -1,7 +1,0 @@
-package nextstep.subway.line.domain;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface SectionRepository extends JpaRepository<Section, Long> {
-
-}

--- a/src/main/java/nextstep/subway/line/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/SectionRepository.java
@@ -1,0 +1,7 @@
+package nextstep.subway.line.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+
+}

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -4,12 +4,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
 import nextstep.subway.station.domain.Station;
 
 @Embeddable
 public class Sections {
 
+    @OneToMany(mappedBy = "line", cascade = CascadeType.ALL)
     private List<Section> sections = new ArrayList<>();
 
     public Sections() {
@@ -19,15 +22,14 @@ public class Sections {
         this.sections = sections;
     }
 
-    public void addSections(Line line, Station upStation, Station downStation, int distance) {
-        this.sections.add(new Section(line, upStation, downStation, distance));
+    public void addSections(Section section) {
+        sections.add(section);
     }
 
     public List<Section> orderedSections() {
         List<Section> orderedSections = new ArrayList();
         Section now = findFirstSection(sections.get(0));
         orderedSections.add(now);
-
         while (orderedSections.size() != sections.size()) {
             Section next = findDownSection(now);
             orderedSections.add(next);
@@ -44,11 +46,17 @@ public class Sections {
     }
 
     private Section findUpSection(Section now) {
-        return sections.stream().filter(section -> section.isUp(now)).findFirst().orElse(now);
+        return sections.stream()
+            .filter(section -> section.isUp(now))
+            .findFirst()
+            .orElse(now);
     }
 
     private Section findDownSection(Section now) {
-        return sections.stream().filter(section -> section.isDown(now)).findFirst().orElse(now);
+        return sections.stream()
+            .filter(section -> section.isDown(now))
+            .findFirst()
+            .orElse(now);
     }
 
     private boolean isFirstSection(Section now) {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -3,6 +3,7 @@ package nextstep.subway.line.domain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.Embeddable;
 import nextstep.subway.station.domain.Station;
 
@@ -14,14 +15,57 @@ public class Sections {
     public Sections() {
     }
 
+    public Sections(List<Section> sections) {
+        this.sections = sections;
+    }
+
     public void addSections(Line line, Station upStation, Station downStation, int distance) {
         this.sections.add(new Section(line, upStation, downStation, distance));
     }
 
-    public List<Section> getSections() {
+    public List<Section> orderedSections() {
+        List<Section> orderedSections = new ArrayList();
+        Section now = findFirstSection(sections.get(0));
+        orderedSections.add(now);
 
-        return Collections.unmodifiableList(sections);
+        while (orderedSections.size() != sections.size()) {
+            Section next = findDownSection(now);
+            orderedSections.add(next);
+            now = next;
+        }
+        return Collections.unmodifiableList(orderedSections);
     }
 
+    private Section findFirstSection(Section now) {
+        if (isFirstSection(now)) {
+            return now;
+        }
+        return findFirstSection(findUpSection(now));
+    }
 
+    private Section findUpSection(Section now) {
+        return sections.stream().filter(section -> section.isUp(now)).findFirst().orElse(now);
+    }
+
+    private Section findDownSection(Section now) {
+        return sections.stream().filter(section -> section.isDown(now)).findFirst().orElse(now);
+    }
+
+    private boolean isFirstSection(Section now) {
+        Section upSection = findUpSection(now);
+        return upSection.equals(now);
+    }
+
+    public List<Station> stations() {
+        List<Section> orderedSections = orderedSections();
+        List<Station> stations = orderedSections.stream()
+            .map(Section::getUpStation)
+            .collect(Collectors.toList());
+        stations.add(orderedSections.get(orderedSections.size() - 1).getDownStation());
+        return stations;
+    }
+
+    public List<Section> getSections() {
+        return Collections.unmodifiableList(sections);
+    }
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,0 +1,27 @@
+package nextstep.subway.line.domain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.persistence.Embeddable;
+import nextstep.subway.station.domain.Station;
+
+@Embeddable
+public class Sections {
+
+    private List<Section> sections = new ArrayList<>();
+
+    public Sections() {
+    }
+
+    public void addSections(Line line, Station upStation, Station downStation, int distance) {
+        this.sections.add(new Section(line, upStation, downStation, distance));
+    }
+
+    public List<Section> getSections() {
+
+        return Collections.unmodifiableList(sections);
+    }
+
+
+}

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -1,17 +1,32 @@
 package nextstep.subway.line.dto;
 
 import nextstep.subway.line.domain.Line;
+import nextstep.subway.station.domain.Station;
 
 public class LineRequest {
     private String name;
     private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
 
     public LineRequest() {
     }
 
-    public LineRequest(String name, String color) {
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
         this.name = name;
         this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public Line toLine() {
+        return new Line(name, color);
+    }
+
+    public Line toLine(Station upStation, Station downStation) {
+        return Line.of(name, color, upStation, downStation, distance);
     }
 
     public String getName() {
@@ -22,7 +37,16 @@ public class LineRequest {
         return color;
     }
 
-    public Line toLine() {
-        return new Line(name, color);
+    public Long getUpStationId() {
+        return upStationId;
     }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
 }

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -4,6 +4,7 @@ import nextstep.subway.line.domain.Line;
 import nextstep.subway.station.domain.Station;
 
 public class LineRequest {
+
     private String name;
     private String color;
     private Long upStationId;
@@ -11,6 +12,11 @@ public class LineRequest {
     private int distance;
 
     public LineRequest() {
+    }
+
+    public LineRequest(String name, String color) {
+        this.name = name;
+        this.color = color;
     }
 
     public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
@@ -28,6 +34,7 @@ public class LineRequest {
     public Line toLine(Station upStation, Station downStation) {
         return Line.of(name, color, upStation, downStation, distance);
     }
+
 
     public String getName() {
         return name;

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -1,29 +1,43 @@
 package nextstep.subway.line.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import nextstep.subway.line.domain.Line;
 
 import java.time.LocalDateTime;
+import nextstep.subway.station.dto.StationResponse;
 
 public class LineResponse {
+
     private Long id;
     private String name;
     private String color;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
+    private List<StationResponse> stations;
 
     public LineResponse() {
     }
 
-    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    public LineResponse(Long id, String name, String color, LocalDateTime createdDate,
+        LocalDateTime modifiedDate, List<StationResponse> stations) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+        this.stations = stations;
     }
 
     public static LineResponse of(Line line) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getCreatedDate(), line.getModifiedDate());
+        return new LineResponse(line.getId(),
+            line.getName(),
+            line.getColor(),
+            line.getCreatedDate(),
+            line.getModifiedDate(),
+            line.stations().stream()
+                .map(StationResponse::of)
+                .collect(Collectors.toList()));
     }
 
     public Long getId() {
@@ -45,4 +59,5 @@ public class LineResponse {
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
     }
+
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -54,6 +54,6 @@ public class LineController {
     @DeleteMapping("/{id}")
     public ResponseEntity delete(@PathVariable("id") Long id) {
         lineService.delete(id);
-        return ResponseEntity.ok().body(null);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/station/StationNotFoundException.java
+++ b/src/main/java/nextstep/subway/station/StationNotFoundException.java
@@ -1,0 +1,10 @@
+package nextstep.subway.station;
+
+import nextstep.subway.common.exception.EntityNotFoundException;
+
+public class StationNotFoundException extends EntityNotFoundException {
+
+    public StationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -1,14 +1,17 @@
 package nextstep.subway.station.domain;
 
+import java.util.Objects;
 import nextstep.subway.common.BaseEntity;
 
 import javax.persistence.*;
 
 @Entity
 public class Station extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(unique = true)
     private String name;
 
@@ -25,5 +28,22 @@ public class Station extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Station station = (Station) o;
+        return Objects.equals(name, station.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/test/java/nextstep/subway/line/domain/LineTest.java
+++ b/src/test/java/nextstep/subway/line/domain/LineTest.java
@@ -1,0 +1,10 @@
+package nextstep.subway.line.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LineTest {
+
+    public static final Line LINE_1 = new Line("1호선", "navy");
+    public static final Line LINE_2 = new Line("2호선", "green");
+
+}

--- a/src/test/java/nextstep/subway/line/domain/SectionTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionTest.java
@@ -1,0 +1,11 @@
+package nextstep.subway.line.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import nextstep.subway.station.domain.StationTest;
+
+public class SectionTest {
+
+    public static final Section SECTION_1 = new Section(LineTest.LINE_2, StationTest.STATION_2, StationTest.STATION_4, 6);
+    public static final Section SECTION_2 = new Section(LineTest.LINE_2, StationTest.STATION_4, StationTest.STATION_3, 10);
+}

--- a/src/test/java/nextstep/subway/line/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionsTest.java
@@ -1,0 +1,36 @@
+package nextstep.subway.line.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import nextstep.subway.station.domain.Station;
+import org.junit.jupiter.api.Test;
+
+class SectionsTest {
+
+    public static final Sections sections = new Sections(Arrays.asList(SectionTest.SECTION_2, SectionTest.SECTION_1));
+
+    @Test
+    void add_section() {
+        assertThat(sections.getSections().get(0).equals(SectionTest.SECTION_2));
+        assertThat(sections.getSections().get(1).equals(SectionTest.SECTION_1));
+    }
+
+    @Test
+    void get_ordered_section() {
+        List<Section> orderedSections = sections.orderedSections();
+        assertThat(orderedSections.get(0)).isEqualTo(SectionTest.SECTION_1);
+        assertThat(orderedSections.get(1)).isEqualTo(SectionTest.SECTION_2);
+    }
+
+    @Test
+    void get_ordered_station() {
+        List<Station> orderedStation = sections.stations();
+        assertThat(orderedStation.get(0)).isEqualTo(SectionTest.SECTION_1.getUpStation());
+        assertThat(orderedStation.get(1)).isEqualTo(SectionTest.SECTION_2.getUpStation());
+        assertThat(orderedStation.get(2)).isEqualTo(SectionTest.SECTION_2.getDownStation());
+    }
+
+}

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -6,6 +6,7 @@ import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.dto.StationResponse;
+import nextstep.subway.utils.CommonMethod;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
+
+    private static final String URL = "/stations";
 
     @DisplayName("지하철역을 생성한다.")
     @Test
@@ -44,7 +47,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
         createStation(name);
 
         // when
-        ExtractableResponse<Response> response = updateStation(name);
+        ExtractableResponse<Response> response = createStation(name);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -87,43 +90,26 @@ public class StationAcceptanceTest extends AcceptanceTest {
     public static ExtractableResponse<Response> createStation(String name) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", name);
-        return RestAssured.given().log().all()
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/stations")
-            .then().log().all()
-            .extract();
+        return CommonMethod.create(params, URL);
     }
 
     private ExtractableResponse<Response> updateStation(String name) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", name);
-        return RestAssured.given().log().all()
-            .body(params)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when()
-            .post("/stations")
-            .then()
-            .log().all()
-            .extract();
+        return CommonMethod.update(params, URL);
     }
 
     private ExtractableResponse<Response> getStations() {
-        return RestAssured.given().log().all()
-            .when()
-            .get("/stations")
-            .then().log().all()
-            .extract();
+        return CommonMethod.get(URL);
     }
 
-    private List<Long> getIdsWithResponse(ExtractableResponse<Response> response){
+    private List<Long> getIdsWithResponse(ExtractableResponse<Response> response) {
         return response.jsonPath().getList(".", StationResponse.class).stream()
             .map(it -> it.getId())
             .collect(Collectors.toList());
     }
 
-    private Long getIdWithResponse(ExtractableResponse<Response> response){
+    private Long getIdWithResponse(ExtractableResponse<Response> response) {
         return response.jsonPath().getObject(".", StationResponse.class).getId();
     }
 

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,21 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
+
     @DisplayName("지하철역을 생성한다.")
     @Test
-    void createStation() {
+    public void create_station() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+        String name = "강남역";
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = createStation(name);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -43,27 +38,13 @@ public class StationAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
     @Test
-    void createStationWithDuplicateName() {
+    void create_station_with_duplicated_name() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        String name = "강남역";
+        createStation(name);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then()
-                .log().all()
-                .extract();
+        ExtractableResponse<Response> response = updateStation(name);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -71,69 +52,79 @@ public class StationAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("지하철역을 조회한다.")
     @Test
-    void getStations() {
+    void get_stations() {
         /// given
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", "강남역");
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
-
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", "역삼역");
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        Long firstId = getIdWithResponse(createStation("강남역"));
+        Long secondId = getIdWithResponse(createStation("역삼역"));
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = getStations();
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
-                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
-                .collect(Collectors.toList());
-        List<Long> resultLineIds = response.jsonPath().getList(".", StationResponse.class).stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-        assertThat(resultLineIds).containsAll(expectedLineIds);
+        List<Long> resultLineIds = getIdsWithResponse(response);
+        assertThat(resultLineIds).containsAll(Arrays.asList(firstId, secondId));
     }
 
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse = createStation("강남역");
 
         // when
         String uri = createResponse.header("Location");
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+            .when()
+            .delete(uri)
+            .then().log().all()
+            .extract();
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    public static ExtractableResponse<Response> createStation(String name) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", name);
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/stations")
+            .then().log().all()
+            .extract();
+    }
+
+    private ExtractableResponse<Response> updateStation(String name) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", name);
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/stations")
+            .then()
+            .log().all()
+            .extract();
+    }
+
+    private ExtractableResponse<Response> getStations() {
+        return RestAssured.given().log().all()
+            .when()
+            .get("/stations")
+            .then().log().all()
+            .extract();
+    }
+
+    private List<Long> getIdsWithResponse(ExtractableResponse<Response> response){
+        return response.jsonPath().getList(".", StationResponse.class).stream()
+            .map(it -> it.getId())
+            .collect(Collectors.toList());
+    }
+
+    private Long getIdWithResponse(ExtractableResponse<Response> response){
+        return response.jsonPath().getObject(".", StationResponse.class).getId();
+    }
+
 }

--- a/src/test/java/nextstep/subway/station/domain/StationTest.java
+++ b/src/test/java/nextstep/subway/station/domain/StationTest.java
@@ -1,0 +1,12 @@
+package nextstep.subway.station.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StationTest {
+
+    public static final Station STATION_1 = new Station("서울역");
+    public static final Station STATION_2 = new Station("신도림역");
+    public static final Station STATION_3 = new Station("성수역");
+    public static final Station STATION_4 = new Station("신촌역");
+
+}

--- a/src/test/java/nextstep/subway/utils/CommonMethod.java
+++ b/src/test/java/nextstep/subway/utils/CommonMethod.java
@@ -1,0 +1,57 @@
+package nextstep.subway.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import nextstep.subway.common.exception.ErrorResponse;
+import org.springframework.http.MediaType;
+
+public class CommonMethod {
+
+    public static ExtractableResponse<Response> create(Map<String, Object> params, String path) {
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post(path)
+            .then().log().all()
+            .extract();
+    }
+
+
+    public static ExtractableResponse<Response> get(String path) {
+        return RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get(path)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> update(Map<String, Object> params, String path) {
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .put(path)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> delete(String path) {
+        return RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .delete(path)
+            .then().log().all()
+            .extract();
+    }
+
+
+    public static ErrorResponse getError(ExtractableResponse<Response> response) {
+        return response.response().jsonPath().getObject(".", ErrorResponse.class);
+    }
+
+
+}


### PR DESCRIPTION
인수테스트 2단계 미션을 구현하였습니다!

✔️ 1단계 미션의 피드백 적용
✔️ Section 객체를 이용하여 노선 생성 시 상행, 하행 정보를 함께 추가
✔️ List Section의 래퍼 클래스 Sections 구현
✔️ Sections를 임베디드 타입으로 구현하여 책임 분리
✔️ 노선 조회 시 section 정보를 활용하여 노선에 포함된 역을 순차대로 반환하는 코드 구현
✔️ LineAcceptanceTest와 StationAcceptanceTest의 공통 메서드를 static 메서드로 뽑아내여 중복 제거 

감사합니다!!🙌 😀 새해 복 많이 받으세요 🥟 =) !