### PR TITLE
Feat: 인수테스트 미션 3단계 구현

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -77,7 +77,10 @@ public class LineService {
             .orElseThrow(() -> new LineNotFoundException(id + " : 존재하지 않는 라인입니다."));
     }
 
-    public void addSection(SectionRequest sectionRequest, Long id) {
-
+    public void addSection(SectionRequest request, Long id) {
+        Line line = line(id);
+        Station upStation = station(request.getUpStationId());
+        Station downStation = station(request.getDownStationId());
+        line.addSection(request.of(line, upStation, downStation));
     }
 }

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -6,6 +6,7 @@ import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.line.exception.LineNotFoundException;
 import nextstep.subway.line.exception.NameDuplicateException;
 import nextstep.subway.station.StationNotFoundException;
@@ -74,5 +75,9 @@ public class LineService {
     private Line line(Long id) {
         return lineRepository.findById(id)
             .orElseThrow(() -> new LineNotFoundException(id + " : 존재하지 않는 라인입니다."));
+    }
+
+    public void addSection(SectionRequest sectionRequest, Long id) {
+
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -37,7 +37,11 @@ public class Line extends BaseEntity {
     }
 
     public void addSections(Station upStation, Station downStation, int distance) {
-        this.sections.addSections(Section.of(this, upStation, downStation, distance));
+        this.sections = Sections.of(Section.of(this, upStation, downStation, distance));
+    }
+
+    public void addSection(Section section){
+        this.sections.addSection(section);
     }
 
     public void update(Line line) {

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -8,6 +8,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import nextstep.subway.line.exception.SectionAlreadyExistInTheLineException;
+import nextstep.subway.line.exception.SectionDistanceExceededException;
 import nextstep.subway.station.domain.Station;
 
 @Entity
@@ -51,6 +53,51 @@ public class Section {
 
     public boolean isDown(Section section) {
         return this.upStation.equals(section.getDownStation());
+    }
+
+    public void addInnerSection(Section section) {
+        if (hasEqualUpStation(section)) {
+            addUpwardInnerSection(section);
+        }
+        if (hasEqualDownStation(section)) {
+            addDownWardInnerSection(section);
+        }
+    }
+
+    private void addUpwardInnerSection(Section section) {
+        checkInnerDistance(section.getDistance());
+        this.distance -= section.getDistance();
+        this.upStation = section.getDownStation();
+    }
+
+    private void addDownWardInnerSection(Section section) {
+        checkInnerDistance(section.getDistance());
+        this.distance -= section.getDistance();
+        this.downStation = section.getUpStation();
+    }
+
+    private boolean hasEqualStations(Section section) {
+        return hasEqualUpStation(section) && hasEqualDownStation(section);
+    }
+
+    private boolean hasEqualUpStation(Section section) {
+        return this.upStation.equals(section.getUpStation());
+    }
+
+    private boolean hasEqualDownStation(Section section) {
+        return this.downStation.equals(section.getDownStation());
+    }
+
+    public void checkStationsDuplicate(Section section) {
+        if (hasEqualStations(section)) {
+            throw new SectionAlreadyExistInTheLineException("등록하려는 구간이 이미 노선에 존재합니다.");
+        }
+    }
+
+    private void checkInnerDistance(int distance) {
+        if (this.distance <= distance) {
+            throw new SectionDistanceExceededException("역 사이에 추가하려는 구간의 거리는 원래 구간 거리보다 작아야 합니다.");
+        }
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,12 +1,14 @@
 package nextstep.subway.line.domain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
+import nextstep.subway.line.exception.StationsNotExistInTheLine;
 import nextstep.subway.station.domain.Station;
 
 @Embeddable
@@ -18,12 +20,37 @@ public class Sections {
     public Sections() {
     }
 
-    public Sections(List<Section> sections) {
+    private Sections(List<Section> sections) {
         this.sections = sections;
     }
 
-    public void addSections(Section section) {
+    public static Sections of(Section... sections) {
+        return new Sections(new ArrayList<>(Arrays.asList(sections)));
+    }
+
+    public void addSection(Section section) {
+        checkSection(section);
+        sections.stream()
+            .forEach(s -> s.addInnerSection(section));
         sections.add(section);
+    }
+
+    private void checkSection(Section section) {
+        checkStationsDuplicate(section);
+        checkStationExist(section);
+    }
+
+    private void checkStationsDuplicate(Section section) {
+        sections.stream()
+            .forEach(s -> s.checkStationsDuplicate(section));
+    }
+
+    private void checkStationExist(Section section) {
+        List<Station> stations = stations();
+        if (!stations.contains(section.getUpStation()) &&
+            !stations.contains(section.getDownStation())) {
+            throw new StationsNotExistInTheLine("상행역과 하행역 둘중 하나는 노선에 존재해야 합니다.");
+        }
     }
 
     public List<Section> orderedSections() {

--- a/src/main/java/nextstep/subway/line/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/SectionRequest.java
@@ -1,0 +1,16 @@
+package nextstep.subway.line.dto;
+
+public class SectionRequest {
+
+    private long downStationId;
+
+    private long upStationId;
+
+    private int distance;
+
+    public SectionRequest(long downStationId, long upStationId, int distance) {
+        this.downStationId = downStationId;
+        this.upStationId = upStationId;
+        this.distance = distance;
+    }
+}

--- a/src/main/java/nextstep/subway/line/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/SectionRequest.java
@@ -1,5 +1,9 @@
 package nextstep.subway.line.dto;
 
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.station.domain.Station;
+
 public class SectionRequest {
 
     private long downStationId;
@@ -12,5 +16,21 @@ public class SectionRequest {
         this.downStationId = downStationId;
         this.upStationId = upStationId;
         this.distance = distance;
+    }
+
+    public Section of(Line line, Station upStation, Station downStation) {
+        return Section.of(line, upStation, downStation, distance);
+    }
+
+    public long getDownStationId() {
+        return downStationId;
+    }
+
+    public long getUpStationId() {
+        return upStationId;
+    }
+
+    public int getDistance() {
+        return distance;
     }
 }

--- a/src/main/java/nextstep/subway/line/exception/SectionAlreadyExistInTheLineException.java
+++ b/src/main/java/nextstep/subway/line/exception/SectionAlreadyExistInTheLineException.java
@@ -1,0 +1,10 @@
+package nextstep.subway.line.exception;
+
+import nextstep.subway.common.exception.InvalidValueException;
+
+public class SectionAlreadyExistInTheLineException extends InvalidValueException {
+
+    public SectionAlreadyExistInTheLineException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/exception/SectionDistanceExceededException.java
+++ b/src/main/java/nextstep/subway/line/exception/SectionDistanceExceededException.java
@@ -1,0 +1,10 @@
+package nextstep.subway.line.exception;
+
+import nextstep.subway.common.exception.InvalidValueException;
+
+public class SectionDistanceExceededException extends InvalidValueException {
+
+    public SectionDistanceExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/exception/StationsNotExistInTheLine.java
+++ b/src/main/java/nextstep/subway/line/exception/StationsNotExistInTheLine.java
@@ -1,0 +1,10 @@
+package nextstep.subway.line.exception;
+
+import nextstep.subway.common.exception.InvalidValueException;
+
+public class StationsNotExistInTheLine extends InvalidValueException {
+
+    public StationsNotExistInTheLine(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -34,7 +34,8 @@ public class LineController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity updateLine(@RequestBody LineRequest lineRequest, @PathVariable("id") Long id) {
+    public ResponseEntity updateLine(@RequestBody LineRequest lineRequest,
+        @PathVariable("id") Long id) {
         LineResponse line = lineService.update(lineRequest, id);
         return ResponseEntity.ok().body(line);
     }
@@ -60,6 +61,6 @@ public class LineController {
     @PostMapping("/{id}/sections")
     public ResponseEntity addSection(@RequestBody SectionRequest sectionRequest, @PathVariable("id") Long id) {
         lineService.addSection(sectionRequest, id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,8 +34,7 @@ public class LineController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity updateLine(@RequestBody LineRequest lineRequest,
-        @PathVariable("id") Long id) {
+    public ResponseEntity updateLine(@RequestBody LineRequest lineRequest, @PathVariable("id") Long id) {
         LineResponse line = lineService.update(lineRequest, id);
         return ResponseEntity.ok().body(line);
     }
@@ -54,6 +54,12 @@ public class LineController {
     @DeleteMapping("/{id}")
     public ResponseEntity delete(@PathVariable("id") Long id) {
         lineService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/sections")
+    public ResponseEntity addSection(@RequestBody SectionRequest sectionRequest, @PathVariable("id") Long id) {
+        lineService.addSection(sectionRequest, id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -212,7 +212,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
             .isEqualTo(id + LINE_NOT_FOUND_EXCEPTION);
     }
 
-    private ExtractableResponse<Response> createLine(String name, String color, long upStationId, long downStationId, int distance) {
+    public static ExtractableResponse<Response> createLine(String name, String color, long upStationId, long downStationId, int distance) {
         Map<String, Object> params = body(name, color, upStationId, downStationId, distance);
         return CommonMethod.create(params, URL);
     }
@@ -245,7 +245,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         return response.jsonPath().getObject(".", LineResponse.class);
     }
 
-    private Map<String, Object> body(String name, String color, long upStationId,
+    private static Map<String, Object> body(String name, String color, long upStationId,
         long downStationId, int distance) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", name);

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -6,7 +6,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Stream;
+import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.station.dto.StationResponse;
@@ -15,26 +15,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 
-public class SectionAcceptanceTest {
+public class SectionAcceptanceTest extends AcceptanceTest {
 
-    private static final String EXCEEDED_DISTANCE_EXCEPTION = "역 사이에 추가하려는 구간의 거리는 원래 구간 거리보다 작아야 합니다.";
-    private static final String SECTION_ALREADY_EXIST_EXCEPTION = "등록하려는 구간이 이미 노선에 존재합니다.";
-    private static final String STATION_NOT_MATCH_EXCEPTION = "상행역과 하행역 둘중 하나는 노선에 존재해야 합니다.";
+    private static final String SECTION_DISTANCE_EXCEEDED_EXCEPTION = "역 사이에 추가하려는 구간의 거리는 원래 구간 거리보다 작아야 합니다.";
+    private static final String SECTION_ALREADY_EXIST_IN_THE_LINE_EXCEPTION = "등록하려는 구간이 이미 노선에 존재합니다.";
+    private static final String STATIONS_NOT_EXIST_IN_THE_LINE_EXCEPTION = "상행역과 하행역 둘중 하나는 노선에 존재해야 합니다.";
 
     private static final String URL = "/lines";
 
     private Long startStationID;
     private Long endStationId;
+    private int originalDistance = 10;
     private Long lineId;
-    private int originalDistance;
 
     @BeforeEach
-    void setUp() {
+    void stationAndLineSetUp() {
         startStationID = StationAcceptanceTest
             .createStation("신도림역")
             .jsonPath()
@@ -56,13 +54,59 @@ public class SectionAcceptanceTest {
         );
     }
 
-    @DisplayName("노선에 지하철역을 추가한다.")
-    @ParameterizedTest
-    @MethodSource("section")
-    void add_station_to_line(Long upStationId, Long downStationId, int distance) {
+    @DisplayName("노선 사이에 새로운 지하철역을 추가한다.")
+    @Test
+    void add_station_to_line() {
+        // given
+        // 지하철_노선에_추가할_중간역을_등록
+        Long middleStationId = StationAcceptanceTest
+            .createStation("신촌역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
         // when
         // 지하철_노선에_지하철역_등록_요청
-        ExtractableResponse<Response> response = addSection(upStationId, downStationId, distance);
+        ExtractableResponse<Response> response = addSection(startStationID, middleStationId, 4);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("노선에 상행 종점역을 추가한다.")
+    @Test
+    void add_first_station_to_line() {
+        // given
+        // 지하철_노선에_추가할_상행_종점을_등록
+        Long firstStationId = StationAcceptanceTest
+            .createStation("까치산역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(firstStationId, startStationID, 5);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("노선에 하행 종점역을 추가한다.")
+    @Test
+    void add_final_station_to_line() {
+        // given
+        // 지하철_노선에_추가할_하행_종점을_등록
+        Long lastStationId = StationAcceptanceTest
+            .createStation("신설동역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(endStationId, lastStationId, 7);
 
         // then
         // 지하철_노선에_지하철역_등록됨
@@ -73,6 +117,8 @@ public class SectionAcceptanceTest {
     @ParameterizedTest
     @ValueSource(ints = {10, 15, 19})
     void section_with_equal_to_or_greater_than_original_distance_is_invalid(int distance) {
+        // given
+        // 지하철_노선에_추가할_역_등록
         Long middleStationId = StationAcceptanceTest
             .createStation("신촌역")
             .jsonPath()
@@ -81,13 +127,13 @@ public class SectionAcceptanceTest {
 
         // when
         // 지하철_노선에_지하철역_등록_요청
-        ExtractableResponse<Response> response = addSection(middleStationId, endStationId,
-            distance);
+        ExtractableResponse<Response> response = addSection(middleStationId, endStationId, distance);
 
         // then
         // 지하철_노선에_지하철역_등록됨
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(EXCEEDED_DISTANCE_EXCEPTION);
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(
+            SECTION_DISTANCE_EXCEEDED_EXCEPTION);
     }
 
     @DisplayName("이미 노선에 등록된 상행역과 하행역으로 이루어진 구간은 노선에 추가될 수 없다.")
@@ -100,12 +146,15 @@ public class SectionAcceptanceTest {
         // then
         // 지하철_노선에_지하철역_등록됨
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(SECTION_ALREADY_EXIST_EXCEPTION);
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(
+            SECTION_ALREADY_EXIST_IN_THE_LINE_EXCEPTION);
     }
 
     @DisplayName("상행역과 하행역 모두 노선에 없는 역으로 이루어진 구간은 노선에 추가될 수 없다.")
     @Test
     void section_with_stations_not_in_the_line_is_invalid() {
+        // given
+        // 지하철_노선에_없는역_등록
         Long firstStationId = StationAcceptanceTest
             .createStation("까치산역")
             .jsonPath()
@@ -123,32 +172,10 @@ public class SectionAcceptanceTest {
         // then
         // 지하철_노선에_지하철역_등록됨
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(STATION_NOT_MATCH_EXCEPTION);
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(
+            STATIONS_NOT_EXIST_IN_THE_LINE_EXCEPTION);
     }
 
-    private Stream<Arguments> section() {
-        Long middleStationId = StationAcceptanceTest
-            .createStation("신촌역")
-            .jsonPath()
-            .getObject(".", StationResponse.class)
-            .getId();
-        Long firstStationId = StationAcceptanceTest
-            .createStation("까치산역")
-            .jsonPath()
-            .getObject(".", StationResponse.class)
-            .getId();
-        Long lastStationId = StationAcceptanceTest
-            .createStation("신설동역")
-            .jsonPath()
-            .getObject(".", StationResponse.class)
-            .getId();
-
-        return Stream.of(
-            Arguments.of(startStationID, middleStationId, 4),
-            Arguments.of(firstStationId, startStationID, 5),
-            Arguments.of(endStationId, lastStationId, 7)
-        );
-    }
 
     private ExtractableResponse<Response> addSection(Long upStationId, Long downStationId,
         int distance) {

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -1,0 +1,106 @@
+package nextstep.subway.line;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.dto.StationResponse;
+import nextstep.subway.utils.CommonMethod;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+
+public class SectionAcceptanceTest {
+
+    private static final String URL = "/lines";
+
+    private Long startStationID;
+    private Long endStationId;
+    private Long lineId;
+    private int originalDistance;
+
+    void setUp() {
+        startStationID = StationAcceptanceTest
+            .createStation("신도림역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+
+        endStationId = StationAcceptanceTest
+            .createStation("잠실역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+        originalDistance = 10;
+        lineId = getIdWithResponse(LineAcceptanceTest
+            .createLine("2호선",
+                "green",
+                startStationID,
+                endStationId,
+                originalDistance)
+        );
+    }
+
+    @DisplayName("노선에 지하철역을 추가한다.")
+    @ParameterizedTest
+    @MethodSource("section")
+    void add_station_to_line(Long upStationId, Long downStationId, int distance) {
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(upStationId, downStationId, distance);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private Stream<Arguments> section() {
+        Long middleStationId = StationAcceptanceTest
+            .createStation("신촌역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+        Long firstStationId = StationAcceptanceTest
+            .createStation("까치산역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+        Long lastStationId = StationAcceptanceTest
+            .createStation("신설동역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+
+        return Stream.of(
+            Arguments.of(startStationID, middleStationId, 4),
+            Arguments.of(firstStationId, startStationID, 5),
+            Arguments.of(endStationId, lastStationId, 7)
+        );
+    }
+
+    private ExtractableResponse<Response> addSection(Long upStationId, Long downStationId,
+        int distance) {
+        Map<String, Object> params = body(upStationId, downStationId, distance);
+        return CommonMethod.create(params, URL + "/" + lineId + "/sections");
+    }
+
+    private Map<String, Object> body(Long upStationId, Long downStationId, int distance) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("upStationId", upStationId);
+        params.put("downStationId", downStationId);
+        params.put("distance", distance);
+        return params;
+    }
+
+    private Long getIdWithResponse(ExtractableResponse<Response> response) {
+        return response.jsonPath().getObject(".", LineResponse.class).getId();
+    }
+
+}

--- a/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/SectionAcceptanceTest.java
@@ -11,13 +11,20 @@ import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.station.dto.StationResponse;
 import nextstep.subway.utils.CommonMethod;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 
 public class SectionAcceptanceTest {
+
+    private static final String EXCEEDED_DISTANCE_EXCEPTION = "역 사이에 추가하려는 구간의 거리는 원래 구간 거리보다 작아야 합니다.";
+    private static final String SECTION_ALREADY_EXIST_EXCEPTION = "등록하려는 구간이 이미 노선에 존재합니다.";
+    private static final String STATION_NOT_MATCH_EXCEPTION = "상행역과 하행역 둘중 하나는 노선에 존재해야 합니다.";
 
     private static final String URL = "/lines";
 
@@ -26,6 +33,7 @@ public class SectionAcceptanceTest {
     private Long lineId;
     private int originalDistance;
 
+    @BeforeEach
     void setUp() {
         startStationID = StationAcceptanceTest
             .createStation("신도림역")
@@ -59,6 +67,63 @@ public class SectionAcceptanceTest {
         // then
         // 지하철_노선에_지하철역_등록됨
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("원래 총 거리보다 크거나 같은 구간은 노선의 중간역으로 추가될 수 없다.")
+    @ParameterizedTest
+    @ValueSource(ints = {10, 15, 19})
+    void section_with_equal_to_or_greater_than_original_distance_is_invalid(int distance) {
+        Long middleStationId = StationAcceptanceTest
+            .createStation("신촌역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(middleStationId, endStationId,
+            distance);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(EXCEEDED_DISTANCE_EXCEPTION);
+    }
+
+    @DisplayName("이미 노선에 등록된 상행역과 하행역으로 이루어진 구간은 노선에 추가될 수 없다.")
+    @Test
+    void section_with_stations_already_in_the_line_is_invalid() {
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(startStationID, endStationId, 3);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(SECTION_ALREADY_EXIST_EXCEPTION);
+    }
+
+    @DisplayName("상행역과 하행역 모두 노선에 없는 역으로 이루어진 구간은 노선에 추가될 수 없다.")
+    @Test
+    void section_with_stations_not_in_the_line_is_invalid() {
+        Long firstStationId = StationAcceptanceTest
+            .createStation("까치산역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+        Long lastStationId = StationAcceptanceTest
+            .createStation("신설동역")
+            .jsonPath()
+            .getObject(".", StationResponse.class)
+            .getId();
+        // when
+        // 지하철_노선에_지하철역_등록_요청
+        ExtractableResponse<Response> response = addSection(firstStationId, lastStationId, 10);
+
+        // then
+        // 지하철_노선에_지하철역_등록됨
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(CommonMethod.getError(response).getMessage()).isEqualTo(STATION_NOT_MATCH_EXCEPTION);
     }
 
     private Stream<Arguments> section() {

--- a/src/test/java/nextstep/subway/line/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionsTest.java
@@ -1,19 +1,19 @@
 package nextstep.subway.line.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.List;
 import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationTest;
 import org.junit.jupiter.api.Test;
 
 class SectionsTest {
 
-    public static final Sections sections = new Sections(Arrays.asList(SectionTest.SECTION_2, SectionTest.SECTION_1));
+    public static final Sections sections = Sections
+        .of(SectionTest.SECTION_2, SectionTest.SECTION_1);
 
     @Test
-    void add_section() {
+    void create_sections() {
         assertThat(sections.getSections().get(0).equals(SectionTest.SECTION_2));
         assertThat(sections.getSections().get(1).equals(SectionTest.SECTION_1));
     }
@@ -32,5 +32,54 @@ class SectionsTest {
         assertThat(orderedStation.get(1)).isEqualTo(SectionTest.SECTION_2.getUpStation());
         assertThat(orderedStation.get(2)).isEqualTo(SectionTest.SECTION_2.getDownStation());
     }
+
+    @Test
+    void add_section_in_the_middle() {
+        //given
+        int distance = 3;
+        int originalDistance = SectionTest.SECTION_2.getDistance();
+        Section section = Section
+            .of(LineTest.LINE_2, StationTest.STATION_4, StationTest.STATION_1, distance);
+
+        //when
+        sections.addSection(section);
+        List<Section> orderedSections = sections.orderedSections();
+
+        //then
+        assertThat(sections.getSections().size()).isEqualTo(3);
+        assertThat(orderedSections.get(1).getDownStation())
+            .isEqualTo(orderedSections.get(2).getUpStation());
+        assertThat(orderedSections.get(2).getDistance()).isEqualTo(originalDistance - distance);
+    }
+
+    @Test
+    void add_first_section() {
+        //given
+        Section section = Section
+            .of(LineTest.LINE_2, StationTest.STATION_1, StationTest.STATION_2, 10);
+
+        //when
+        sections.addSection(section);
+
+        //then
+        assertThat(sections.getSections().size()).isEqualTo(3);
+        assertThat(sections.orderedSections().get(0)).isEqualTo(section);
+    }
+
+
+    @Test
+    void add_last_section() {
+        //given
+        Section section = Section
+            .of(LineTest.LINE_2, StationTest.STATION_3, StationTest.STATION_1, 10);
+
+        //when
+        sections.addSection(section);
+
+        //then
+        assertThat(sections.getSections().size()).isEqualTo(3);
+        assertThat(sections.orderedSections().get(2)).isEqualTo(section);
+    }
+
 
 }


### PR DESCRIPTION
인수테스트 미션 3단계를 구현하였습니다!

✔️ 인수테스트를 먼저 작성하고 로직을 구현
✔️ 지하철역 등록시 addInnerSection 메소드를 이용하여 중간역에 넣을 시 기존의 Section 및 새로운 Section 수정하도록 구현
✔️ 예외 상황 별 커스텀 된 예외가 발생되도록 구현
✔️ 지하철 역 등록에 대한 SectionsTest 테스트 코드 구현

마지막 커밋(비지니스 로직 구현, 테스트 코드 추가 및 리팩토링)을 나눠서 진행하지 못하였습니다 😭 죄송합니다 😭
감사합니다! 🙌