### PR TITLE
[ATDD] 1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ This project is [MIT](https://github.com/next-step/atdd-subway-admin/blob/master
 ### 기능 요구사항
 
 - [ ] 지하철역 관련 인수 테스트를 완성하세요.
-  - [ ] 지하철역 목록 조회 인수 테스트 작성하기
+  - [X] 지하철역 목록 조회 인수 테스트 작성하기
   - [ ] 지하철역 삭제 인수 테스트 작성하기

--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ npm run dev
 ## 📝 License
 
 This project is [MIT](https://github.com/next-step/atdd-subway-admin/blob/master/LICENSE.md) licensed.
+
+
+## 1단계 - 지하철역 인수 테스트 작성
+
+### 기능 요구사항
+
+- [ ] 지하철역 관련 인수 테스트를 완성하세요.
+  - [ ] 지하철역 목록 조회 인수 테스트 작성하기
+  - [ ] 지하철역 삭제 인수 테스트 작성하기

--- a/README.md
+++ b/README.md
@@ -58,6 +58,5 @@ This project is [MIT](https://github.com/next-step/atdd-subway-admin/blob/master
 
 ### 기능 요구사항
 
-- [ ] 지하철역 관련 인수 테스트를 완성하세요.
-  - [X] 지하철역 목록 조회 인수 테스트 작성하기
-  - [ ] 지하철역 삭제 인수 테스트 작성하기
+- [X] 지하철역 목록 조회 인수 테스트 작성하기
+- [X] 지하철역 삭제 인수 테스트 작성하기

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -39,16 +39,7 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = 지하철역_생성("강남역");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -71,23 +62,10 @@ public class StationAcceptanceTest {
     @Test
     void createStationWithDuplicateName() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations")
-                .then().log().all();
+        지하철역_생성("강남역");
 
         // when
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = 지하철역_생성("강남역");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -101,6 +79,19 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 조회한다.")
     @Test
     void getStations() {
+        // given
+        지하철역_생성("강남역");
+        지하철역_생성("역삼역");
+
+        // when
+        List<String> stationNames =
+                RestAssured.given().log().all()
+                        .when().get("/stations")
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+
+        // then
+        assertThat(stationNames).containsExactly("강남역", "역삼역");
     }
 
     /**
@@ -111,5 +102,17 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
+    }
+
+    private ExtractableResponse<Response> 지하철역_생성(String name) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", name);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -3,6 +3,8 @@ package nextstep.subway.station;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.domain.Station;
+import nextstep.subway.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,6 +104,24 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
+        // given
+        ExtractableResponse<Response> response = 지하철역_생성("강남역");
+
+        // when
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete("/stations/" + response.body().jsonPath().get("id"))
+                .then().log().all()
+                .extract();
+
+        // then
+        List<StationResponse> stations = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("", StationResponse.class);
+
+        assertThat(stations).isEmpty();
     }
 
     private ExtractableResponse<Response> 지하철역_생성(String name) {


### PR DESCRIPTION
안녕하세요! 인수테스트를 진행하게 된 이성혁입니다.

RestAssured 를 이용한 테스트 코드 작성은 처음이라 낯설었지만 코드의 가독성이 좋았고 로그 확인도 편리했던거 같습니다.
이번에 작성하며 느낀건 하나의 도메인(지하철역)에 CRUD는 공통으로 사용하도록 분리하여 재사용하는 것이 좋다고 생각했습니다.

결국 인수테스트는 작성한 시나리오 순서로 동작하는지 확인하는 것이라 생각되어
RestAssured 코드는 분리하여 한글 메소드명으로 숨기는 것이 어떠한가 생각되었습니다.

결론은
StationAcceptanceTestFixture 클래스를 생성하여 여기에 RestAssured 부분을 작성하고 
StationAcceptanceTest 클래스에서는 호출만하는 방식으로 사용하는 것이 어떤지 의견이 궁금합니다. 혹은 일반적으로 사용하는 방법이 무엇이 있을까요? 아직 기준이 명확하지 잡혀있지 않아서 고민중입니다. 

의견주시면 감사하겠습니다!